### PR TITLE
EXIT_CODE_TIME_LIMIT number change

### DIFF
--- a/miner.h
+++ b/miner.h
@@ -725,7 +725,7 @@ extern void tq_thaw(struct thread_q *tq);
 #define EXIT_CODE_SW_INIT_ERROR 3
 #define EXIT_CODE_CUDA_NODEVICE 4
 #define EXIT_CODE_CUDA_ERROR    5
-#define EXIT_CODE_TIME_LIMIT    0
+#define EXIT_CODE_TIME_LIMIT    6
 #define EXIT_CODE_KILLED        7
 
 void parse_arg(int key, char *arg);


### PR DESCRIPTION
Was 0, which is the same as EXIT_CODE_OK, believe it was meant to be a six?
