### PR TITLE
fixed loop bug to get correct hashrates

### DIFF
--- a/Algo256/bmw.cu
+++ b/Algo256/bmw.cu
@@ -108,14 +108,9 @@ extern "C" int scanhash_bmw(int thr_id, struct work* work, uint32_t max_nonce, u
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 	return 0;

--- a/Algo256/keccak256.cu
+++ b/Algo256/keccak256.cu
@@ -99,14 +99,9 @@ extern "C" int scanhash_keccak256(int thr_id, struct work* work, uint32_t max_no
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 	return 0;

--- a/Algo256/vanilla.cu
+++ b/Algo256/vanilla.cu
@@ -461,14 +461,9 @@ extern "C" int scanhash_vanilla(int thr_id, struct work* work, uint32_t max_nonc
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 	MyStreamSynchronize(NULL, 0, dev_id);

--- a/JHA/jackpotcoin.cu
+++ b/JHA/jackpotcoin.cu
@@ -251,14 +251,9 @@ extern "C" int scanhash_jackpot(int thr_id, struct work *work, uint32_t max_nonc
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 

--- a/JHA/jha.cu
+++ b/JHA/jha.cu
@@ -226,14 +226,9 @@ extern "C" int scanhash_jha(int thr_id, struct work *work, uint32_t max_nonce, u
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 

--- a/crypto/cryptolight.cu
+++ b/crypto/cryptolight.cu
@@ -130,16 +130,12 @@ extern "C" int scanhash_cryptolight(int thr_id, struct work* work, uint32_t max_
 			}
 		}
 
-		if ((uint64_t) throughput + nonce >= max_nonce - 127) {
-			nonce = max_nonce;
-			break;
-		}
-
 		nonce += throughput;
 		gpulog(LOG_DEBUG, thr_id, "nonce %08x", nonce);
 
 	} while (!work_restart[thr_id].restart && max_nonce > (uint64_t)throughput + nonce);
 
+	*hashes_done = nonce - first_nonce;
 done:
 	gpulog(LOG_DEBUG, thr_id, "nonce %08x exit", nonce);
 	work->valid_nonces = res;

--- a/crypto/cryptonight.cu
+++ b/crypto/cryptonight.cu
@@ -147,16 +147,12 @@ extern "C" int scanhash_cryptonight(int thr_id, struct work* work, uint32_t max_
 			}
 		}
 
-		if ((uint64_t) throughput + nonce >= max_nonce - 127) {
-			nonce = max_nonce;
-			break;
-		}
-
 		nonce += throughput;
 		gpulog(LOG_DEBUG, thr_id, "nonce %08x", nonce);
 
 	} while (!work_restart[thr_id].restart && max_nonce > (uint64_t)throughput + nonce);
 
+	*hashes_done = nonce - first_nonce;
 done:
 	gpulog(LOG_DEBUG, thr_id, "nonce %08x exit", nonce);
 	work->valid_nonces = res;

--- a/crypto/wildkeccak.cu
+++ b/crypto/wildkeccak.cu
@@ -335,15 +335,10 @@ extern "C" int scanhash_wildkeccak(int thr_id, struct work* work, uint32_t max_n
 			}
 		}
 
-		if (n + throughput >= max_nonce) {
-			n = max_nonce;
-			break;
-		}
-
 		n += throughput;
 		nonce += throughput;
 
-	} while(!work_restart[thr_id].restart);
+	} while(!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) nonce + throughput);
 
 	*hashes_done = (unsigned long) (n - first + 1);
 	return 0;

--- a/fuguecoin.cpp
+++ b/fuguecoin.cpp
@@ -85,14 +85,9 @@ int scanhash_fugue256(int thr_id, struct work* work, uint32_t max_nonce, unsigne
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - start_nonce;
 	return 0;

--- a/groestlcoin.cpp
+++ b/groestlcoin.cpp
@@ -86,13 +86,9 @@ int scanhash_groestlcoin(int thr_id, struct work *work, uint32_t max_nonce, unsi
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - start_nonce;
 	return 0;

--- a/heavy/bastion.cu
+++ b/heavy/bastion.cu
@@ -191,13 +191,9 @@ int scanhash_bastion(int thr_id, struct work *work, uint32_t max_nonce, unsigned
 			}
 		}
 
-		if ((uint64_t)throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 

--- a/heavy/heavy.cu
+++ b/heavy/heavy.cu
@@ -281,6 +281,8 @@ int scanhash_heavy(int thr_id, struct work *work, uint32_t max_nonce, unsigned l
 			applog_hash((uchar*)hash);
 		}
 
+		*hashes_done = pdata[19] + throughput - first_nonce;
+
 		// Ergebnisse kopieren
 		if(actualNumberOfValuesInNonceVectorGPU > 0)
 		{
@@ -309,17 +311,12 @@ int scanhash_heavy(int thr_id, struct work *work, uint32_t max_nonce, unsigned l
 		}
 
 emptyNonceVector:
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
-exit:
 	*hashes_done = pdata[19] - first_nonce;
-
+exit:
 	cudaFreeHost(cpu_nonceVector);
 	cudaFreeHost(hash);
 	CUDA_LOG_ERROR();

--- a/lbry/lbry.cu
+++ b/lbry/lbry.cu
@@ -209,14 +209,8 @@ extern "C" int scanhash_lbry(int thr_id, struct work *work, uint32_t max_nonce, 
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[LBC_NONCE_OFT32] >= max_nonce) {
-			pdata[LBC_NONCE_OFT32] = max_nonce;
-			break;
-		}
-
 		pdata[LBC_NONCE_OFT32] += throughput;
-
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[LBC_NONCE_OFT32] + throughput);
 
 	*hashes_done = pdata[LBC_NONCE_OFT32] - first_nonce;
 

--- a/lyra2/lyra2RE.cu
+++ b/lyra2/lyra2RE.cu
@@ -163,13 +163,9 @@ extern "C" int scanhash_lyra2(int thr_id, struct work* work, uint32_t max_nonce,
 			}
 		}
 
-		if ((uint64_t)throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 	return 0;

--- a/lyra2/lyra2REv2.cu
+++ b/lyra2/lyra2REv2.cu
@@ -170,13 +170,9 @@ extern "C" int scanhash_lyra2v2(int thr_id, struct work* work, uint32_t max_nonc
 			}
 		}
 
-		if ((uint64_t)throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart && !abort_flag);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 	return 0;

--- a/lyra2/lyra2Z.cu
+++ b/lyra2/lyra2Z.cu
@@ -135,13 +135,9 @@ extern "C" int scanhash_lyra2Z(int thr_id, struct work* work, uint32_t max_nonce
 			}
 		}
 
-		if ((uint64_t)throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 	return 0;

--- a/myriadgroestl.cpp
+++ b/myriadgroestl.cpp
@@ -102,15 +102,11 @@ int scanhash_myriad(int thr_id, struct work *work, uint32_t max_nonce, unsigned 
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
-	*hashes_done = max_nonce - start_nonce;
+	*hashes_done = pdata[19] - start_nonce;
 
 	return 0;
 }

--- a/neoscrypt/neoscrypt.cpp
+++ b/neoscrypt/neoscrypt.cpp
@@ -92,14 +92,9 @@ int scanhash_neoscrypt(int thr_id, struct work* work, uint32_t max_nonce, unsign
 			}
 		}
 
-		if ((uint64_t)throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 	return 0;

--- a/pentablake.cu
+++ b/pentablake.cu
@@ -131,14 +131,9 @@ extern "C" int scanhash_pentablake(int thr_id, struct work *work, uint32_t max_n
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	return rc;
 }

--- a/quark/nist5.cu
+++ b/quark/nist5.cu
@@ -146,17 +146,12 @@ extern "C" int scanhash_nist5(int thr_id, struct work *work, uint32_t max_nonce,
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
+	*hashes_done = pdata[19] - first_nonce;
 out:
-//	*hashes_done = pdata[19] - first_nonce;
 #ifdef USE_STREAMS
 	for (int i = 0; i < 5; i++)
 		cudaStreamDestroy(stream[i]);

--- a/quark/quarkcoin.cu
+++ b/quark/quarkcoin.cu
@@ -297,14 +297,11 @@ extern "C" int scanhash_quark(int thr_id, struct work* work, uint32_t max_nonce,
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
+
+	*hashes_done = pdata[19] - first_nonce;
 
 	return 0;
 }

--- a/qubit/deep.cu
+++ b/qubit/deep.cu
@@ -128,13 +128,9 @@ extern "C" int scanhash_deep(int thr_id, struct work* work, uint32_t max_nonce, 
 			}
 		}
 
-		if ((uint64_t)throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce + 1;
 	return 0;

--- a/qubit/luffa.cu
+++ b/qubit/luffa.cu
@@ -104,13 +104,9 @@ extern "C" int scanhash_luffa(int thr_id, struct work* work, uint32_t max_nonce,
 			}
 		}
 
-		if ((uint64_t)throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 	return 0;

--- a/qubit/qubit.cu
+++ b/qubit/qubit.cu
@@ -144,13 +144,9 @@ extern "C" int scanhash_qubit(int thr_id, struct work* work, uint32_t max_nonce,
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 	return 0;

--- a/sha256/sha256d.cu
+++ b/sha256/sha256d.cu
@@ -97,14 +97,9 @@ extern "C" int scanhash_sha256d(int thr_id, struct work* work, uint32_t max_nonc
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 

--- a/sha256/sha256t.cu
+++ b/sha256/sha256t.cu
@@ -101,14 +101,9 @@ extern "C" int scanhash_sha256t(int thr_id, struct work* work, uint32_t max_nonc
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 

--- a/sia/sia.cu
+++ b/sia/sia.cu
@@ -274,14 +274,9 @@ int scanhash_sia(int thr_id, struct work *work, uint32_t max_nonce, unsigned lon
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[8] >= max_nonce) {
-			pdata[8] = max_nonce;
-			break;
-		}
-
 		pdata[8] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[8] + throughput);
 
 	*hashes_done = pdata[8] - first_nonce;
 

--- a/skein.cu
+++ b/skein.cu
@@ -449,14 +449,9 @@ extern "C" int scanhash_skeincoin(int thr_id, struct work* work, uint32_t max_no
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 

--- a/skein2.cpp
+++ b/skein2.cpp
@@ -118,14 +118,9 @@ int scanhash_skein2(int thr_id, struct work* work, uint32_t max_nonce, unsigned 
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 

--- a/skunk/skunk.cu
+++ b/skunk/skunk.cu
@@ -177,14 +177,10 @@ extern "C" int scanhash_skunk(int thr_id, struct work* work, uint32_t max_nonce,
 				continue;
 			}
 		}
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
 
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 

--- a/tribus.cu
+++ b/tribus.cu
@@ -133,18 +133,12 @@ extern "C" int scanhash_tribus(int thr_id, struct work *work, uint32_t max_nonce
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
+	*hashes_done = pdata[19] - first_nonce;
 out:
-//	*hashes_done = pdata[19] - first_nonce;
-
 	return work->valid_nonces;
 }
 

--- a/x11/bitcore.cu
+++ b/x11/bitcore.cu
@@ -406,13 +406,9 @@ extern "C" int scanhash_bitcore(int thr_id, struct work* work, uint32_t max_nonc
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 	return 0;

--- a/x11/c11.cu
+++ b/x11/c11.cu
@@ -212,14 +212,9 @@ extern "C" int scanhash_c11(int thr_id, struct work* work, uint32_t max_nonce, u
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 	return 0;

--- a/x11/fresh.cu
+++ b/x11/fresh.cu
@@ -155,13 +155,9 @@ extern "C" int scanhash_fresh(int thr_id, struct work* work, uint32_t max_nonce,
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce + 1;
 	return 0;

--- a/x11/s3.cu
+++ b/x11/s3.cu
@@ -150,14 +150,9 @@ extern "C" int scanhash_s3(int thr_id, struct work* work, uint32_t max_nonce, un
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 	return 0;

--- a/x11/sib.cu
+++ b/x11/sib.cu
@@ -210,13 +210,9 @@ extern "C" int scanhash_sib(int thr_id, struct work* work, uint32_t max_nonce, u
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 	return 0;

--- a/x11/timetravel.cu
+++ b/x11/timetravel.cu
@@ -520,13 +520,9 @@ extern "C" int scanhash_timetravel(int thr_id, struct work* work, uint32_t max_n
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 	return 0;

--- a/x11/veltor.cu
+++ b/x11/veltor.cu
@@ -166,14 +166,10 @@ extern "C" int scanhash_veltor(int thr_id, struct work* work, uint32_t max_nonce
 				continue;
 			}
 		}
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
 
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 

--- a/x11/x11.cu
+++ b/x11/x11.cu
@@ -200,13 +200,9 @@ extern "C" int scanhash_x11(int thr_id, struct work* work, uint32_t max_nonce, u
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 	return 0;

--- a/x11/x11evo.cu
+++ b/x11/x11evo.cu
@@ -381,13 +381,9 @@ extern "C" int scanhash_x11evo(int thr_id, struct work* work, uint32_t max_nonce
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce + 1;
 	return 0;

--- a/x13/x13.cu
+++ b/x13/x13.cu
@@ -216,13 +216,9 @@ extern "C" int scanhash_x13(int thr_id, struct work* work, uint32_t max_nonce, u
 			}
 		}
 
-		if ((uint64_t)throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 

--- a/x15/whirlpool.cu
+++ b/x15/whirlpool.cu
@@ -148,13 +148,9 @@ extern "C" int scanhash_whirl(int thr_id, struct work* work, uint32_t max_nonce,
 				continue;
 			}
 		}
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 	return 0;

--- a/x15/whirlpoolx.cu
+++ b/x15/whirlpoolx.cu
@@ -96,14 +96,9 @@ extern "C" int scanhash_whirlx(int thr_id,  struct work* work, uint32_t max_nonc
 			}
 		}
 
-		if ((uint64_t)throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*(hashes_done) = pdata[19] - first_nonce;
 

--- a/x15/x14.cu
+++ b/x15/x14.cu
@@ -232,14 +232,9 @@ extern "C" int scanhash_x14(int thr_id,  struct work* work, uint32_t max_nonce, 
 			}
 		}
 
-		if ((uint64_t)throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	CUDA_LOG_ERROR();
 

--- a/x15/x15.cu
+++ b/x15/x15.cu
@@ -238,14 +238,9 @@ extern "C" int scanhash_x15(int thr_id,  struct work* work, uint32_t max_nonce, 
 			}
 		}
 
-		if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (!work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 

--- a/x17/hmq17.cu
+++ b/x17/hmq17.cu
@@ -504,14 +504,9 @@ extern "C" int scanhash_hmq17(int thr_id, struct work* work, uint32_t max_nonce,
 			}
 		}
 
-		if ((uint64_t)throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (pdata[19] < max_nonce && !work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 	return 0;

--- a/x17/x17.cu
+++ b/x17/x17.cu
@@ -268,14 +268,9 @@ extern "C" int scanhash_x17(int thr_id, struct work* work, uint32_t max_nonce, u
 			}
 		}
 
-		if ((uint64_t)throughput + pdata[19] >= max_nonce) {
-			pdata[19] = max_nonce;
-			break;
-		}
-
 		pdata[19] += throughput;
 
-	} while (pdata[19] < max_nonce && !work_restart[thr_id].restart);
+	} while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);
 
 	*hashes_done = pdata[19] - first_nonce;
 	return 0;


### PR DESCRIPTION
This is somewhat old bug in the do while() loop found at the `scanhash_*()`

```diff
diff --git a/Algo256/bmw.cu b/Algo256/bmw.cu
index c2e4be6..0baea68 100644
--- a/Algo256/bmw.cu
+++ b/Algo256/bmw.cu
@@ -108,14 +108,9 @@ extern "C" int scanhash_bmw(int thr_id, struct work* work, uint32_t max_nonce, u
                        }
                }

-               if ((uint64_t) throughput + pdata[19] >= max_nonce) {
-                       pdata[19] = max_nonce; // incorrect!!
-                       break;
-               }
-
                pdata[19] += throughput;

-       } while (!work_restart[thr_id].restart);
+       } while (!work_restart[thr_id].restart && (uint64_t) max_nonce > (uint64_t) pdata[19] + throughput);

        *hashes_done = pdata[19] - first_nonce;
        return 0;
```

see also:
https://github.com/KlausT/ccminer/commit/c0f1a819dae6c2ed9882db961239e32b8683c00b