### PR TITLE
make cuda_shutdown() work

### DIFF
--- a/cuda.cpp
+++ b/cuda.cpp
@@ -122,8 +122,8 @@ void cuda_print_devices()
 void cuda_shutdown()
 {
 	// require gpu init first
-	//if (thr_info != NULL)
-	//	cudaDeviceSynchronize();
+	if (thr_info != NULL)
+		cudaDeviceSynchronize();
 	cudaDeviceReset();
 }
 


### PR DESCRIPTION
for some miners `ctrl-C` make CPU 100% load. (eg, -a cryptonight)
This fix partially revert the commit 2479ffaaa29 (accidentally removed?)
and make the `cudaDeviceSynchronze()` called correctly.

btw where is the issue tracker? is there any [bitcointalk ccminer thread](https://bitcointalk.org/?topic=770064) or somthing for dev?