### PR TITLE
Delete the dead code "#include < device_functions_decl.h >" in line 14 of equi/eqcuda.hpp

### DIFF
--- a/equi/eqcuda.hpp
+++ b/equi/eqcuda.hpp
@@ -11,7 +11,6 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <device_launch_parameters.h>
-#include <device_functions_decls.h>
 
 #ifdef WIN32
 #define _SNPRINTF _snprintf


### PR DESCRIPTION
Delete the code that include header file device_functions_decls.h, which is useless for ccminer. ccminer should not generate any NVVM IR or use libdevice. 
I remove '#include < device_functions_decl.h >' from equi/eqcuda.hpp, ccminer builds fine
