### PR TITLE
add sm_61,compute_61 to nvcc_ARCH

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -114,6 +114,7 @@ ccminer_LDADD += -lcuda
 nvcc_ARCH  = -gencode=arch=compute_50,code=\"sm_50,compute_50\"
 
 nvcc_ARCH += -gencode=arch=compute_52,code=\"sm_52,compute_52\"
+nvcc_ARCH += -gencode=arch=compute_61,code=\"sm_61,compute_61\"
 #nvcc_ARCH += -gencode=arch=compute_35,code=\"sm_35,compute_35\"
 #nvcc_ARCH += -gencode=arch=compute_30,code=\"sm_30,compute_30\"
 #nvcc_ARCH += -gencode=arch=compute_20,code=\"sm_21,compute_20\"


### PR DESCRIPTION
The Nvidia cards that are most likely to be used today for mining are the compute_61 architecture. This architecture should be added to the default compile options.

I use sm_61,compute_61 exclusively (I've disabled all other ARCH options) on a 1060 and a Titan X Pascal and it works great.