### PR TITLE
compilation fails on CUDA 9 because of mandatory compute_20

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -176,15 +176,15 @@ JHA/cuda_jha_compactionTest.o: JHA/cuda_jha_compactionTest.cu
 
 # This object does not use cuda device code but call the different kernels (autotune)
 scrypt/salsa_kernel.o: scrypt/salsa_kernel.cu
-	$(NVCC) $(JANSSON_INCLUDES) -I. @CUDA_INCLUDES@ @CUDA_CFLAGS@ -gencode=arch=compute_20,code=\"sm_21,compute_20\" -o $@ -c $<
+	$(NVCC) $(JANSSON_INCLUDES) -I. @CUDA_INCLUDES@ @CUDA_CFLAGS@ -gencode=arch=compute_30,code=\"sm_30,compute_30\" -o $@ -c $<
 
 # These kernels are for older devices (SM)
 
 scrypt/test_kernel.o: scrypt/test_kernel.cu
-	$(NVCC) $(JANSSON_INCLUDES) -I. @CUDA_INCLUDES@ @CUDA_CFLAGS@ -gencode=arch=compute_20,code=\"sm_20,compute_20\" -o $@ -c $<
+	$(NVCC) $(JANSSON_INCLUDES) -I. @CUDA_INCLUDES@ @CUDA_CFLAGS@ -gencode=arch=compute_30,code=\"sm_30,compute_30\" -o $@ -c $<
 
 scrypt/fermi_kernel.o: scrypt/fermi_kernel.cu
-	$(NVCC) $(JANSSON_INCLUDES) -I. @CUDA_INCLUDES@ @CUDA_CFLAGS@ -gencode=arch=compute_20,code=\"sm_21,compute_20\" -o $@ -c $<
+	$(NVCC) $(JANSSON_INCLUDES) -I. @CUDA_INCLUDES@ @CUDA_CFLAGS@ -gencode=arch=compute_30,code=\"sm_30,compute_30\" -o $@ -c $<
 
 scrypt/kepler_kernel.o: scrypt/kepler_kernel.cu
 	$(NVCC) $(JANSSON_INCLUDES) -I. @CUDA_INCLUDES@ @CUDA_CFLAGS@ -gencode=arch=compute_30,code=\"sm_30,compute_30\" -o $@ -c $<


### PR DESCRIPTION
Using Ubuntu 16.04 with a GTX 1060.

If you install CUDA today from https://developer.nvidia.com/cuda-downloads the version you get by default is 9.1. If you try to compile ccminer with this CUDA version, it fails. The reason is that compute_20 has been removed from CUDA 9 (it was deprecated already for a while in previous versions), and the ccminer source contains compute_20 directives in a few places.

The changes I propose in this PR are most certainly wrong. **Please do not merge**. But I cannot open an issue with your Github project, so this seems the best way to communicate.

Anyway, I've compiled my copy of ccminer with the changes shown above and now it's mining lyra2v2 just fine on a GTX 1060.

Something needs to be done about compute_20 and CUDA 9. Either remove compute_20 or add some conditional to skip it on the current version of CUDA.