### PR TITLE
Disable stale work detection on Lyra2Z

### DIFF
--- a/ccminer.cpp
+++ b/ccminer.cpp
@@ -3977,6 +3977,10 @@ int main(int argc, char *argv[])
 		GetScratchpad();
 	}
 
+	if (opt_algo == ALGO_LYRA2Z && !opt_submit_stale) {
+		if (!opt_quiet) applog(LOG_WARNING, "You should consider using --submit-stale when mining Lyra2Z");
+	}
+
 	flags = !opt_benchmark && strncmp(rpc_url, "https:", 6)
 	      ? (CURL_GLOBAL_ALL & ~CURL_GLOBAL_SSL)
 	      : CURL_GLOBAL_ALL;

--- a/ccminer.cpp
+++ b/ccminer.cpp
@@ -901,7 +901,7 @@ static bool submit_upstream_work(CURL *curl, struct work *work)
 
 	/* discard if a newer block was received */
 	stale_work = work->height && work->height < g_work.height;
-	if (have_stratum && !stale_work && !opt_submit_stale && opt_algo != ALGO_ZR5 && opt_algo != ALGO_SCRYPT_JANE && opt_algo != ALGO_LYRA2Z) {
+	if (have_stratum && !stale_work && !opt_submit_stale && opt_algo != ALGO_ZR5 && opt_algo != ALGO_SCRYPT_JANE) {
 		pthread_mutex_lock(&g_work_lock);
 		if (strlen(work->job_id + 8))
 			stale_work = strncmp(work->job_id + 8, g_work.job_id + 8, sizeof(g_work.job_id) - 8);

--- a/ccminer.cpp
+++ b/ccminer.cpp
@@ -901,7 +901,7 @@ static bool submit_upstream_work(CURL *curl, struct work *work)
 
 	/* discard if a newer block was received */
 	stale_work = work->height && work->height < g_work.height;
-	if (have_stratum && !stale_work && !opt_submit_stale && opt_algo != ALGO_ZR5 && opt_algo != ALGO_SCRYPT_JANE) {
+	if (have_stratum && !stale_work && !opt_submit_stale && opt_algo != ALGO_ZR5 && opt_algo != ALGO_SCRYPT_JANE && opt_algo != ALGO_LYRA2Z) {
 		pthread_mutex_lock(&g_work_lock);
 		if (strlen(work->job_id + 8))
 			stale_work = strncmp(work->job_id + 8, g_work.job_id + 8, sizeof(g_work.job_id) - 8);


### PR DESCRIPTION
Description: Disable_stale_work_detection_on_Lyra2Z
 With this feature being enabled hashrate seen by MiningPoolHub
 is reported to be half on what ccminer reports.
 .
 This has been confirmed by several users and is probably the reason why
 ZCoin recommends djm34 ccminer:
 https://zcoin.io/guide-on-how-to-mine-zcoin-xzc/
 .
 This patch is inspired by:
 https://github.com/djm34/ccminer-msvc2015/commit/877b7aa0f65bfa71ee6218eb833309417f792041
 .
 ccminer-tpruvot (2.2.3-3) unstable; urgency=medium
 .
Author: Adam Cecile <acecile@le-vert.net>


Also there's a 20% boost on Zcoin (XZC) if CUDA is limited to level 5.2. I checked this myself with the following results:

|                          | CUDA 8.0 | CUDA 8.2 with 5.2 only | CUDA 9.0| 
|--------------------------|--------------|------------------------|--------------|
| GTX1070                  | 1275 kH/s    | 1496 kH/s              | 1682 kH/s |
| GTX1080                  | 1593 kH/s    | 1871 kH/s              | 2153 kH/s |
| GTX1080 (another)        | 1651 kH/s    | 1932 kH/s              | 2181 kH/s |
| GTX1080Ti (PwrLimit 200) | 2352 kH/s    | 2746 kH/s              | 3103 kH/s |

So I'm not sure how to this with your build system but you should filter out any level above 52 from nvcc_ARCH flags while building the lyra2Z kernel.

Or at least add this to README file explaining how to produce a faster Lyra2Z build.

Best regards, Adam.