### PR TITLE
Cuda9.1

### DIFF
--- a/JHA/cuda_jha_compactionTest.cu
+++ b/JHA/cuda_jha_compactionTest.cu
@@ -72,6 +72,11 @@ void jackpot_compactTest_cpu_free(int thr_id)
 #define __shfl_up(var, delta, width) (0)
 #endif
 
+#if CUDA_VERSION >= 9000
+#undef __shfl_up
+#define __shfl_up(var, delta, width) __shfl_up_sync(0xFFFFFFFF, var, delta, width)
+#endif
+
 // Die Summenfunktion (vom NVIDIA SDK)
 __global__
 void jackpot_compactTest_gpu_SCAN(uint32_t *data, int width, uint32_t *partial_sums=NULL, cuda_compactTestFunction_t testFunc=NULL,

--- a/Makefile.am
+++ b/Makefile.am
@@ -112,8 +112,10 @@ endif
 ccminer_LDADD += -lcuda
 
 nvcc_ARCH  = -gencode=arch=compute_50,code=\"sm_50,compute_50\"
-
 nvcc_ARCH += -gencode=arch=compute_52,code=\"sm_52,compute_52\"
+nvcc_ARCH += -gencode=arch=compute_60,code=\"sm_60,compute_60\"
+nvcc_ARCH += -gencode=arch=compute_61,code=\"sm_61,compute_61\"
+nvcc_ARCH += -gencode=arch=compute_62,code=\"sm_62,compute_62\"
 #nvcc_ARCH += -gencode=arch=compute_35,code=\"sm_35,compute_35\"
 #nvcc_ARCH += -gencode=arch=compute_30,code=\"sm_30,compute_30\"
 

--- a/equi/cuda_equi.cu
+++ b/equi/cuda_equi.cu
@@ -79,6 +79,13 @@ u32 umin(const u32, const u32);
 u32 umax(const u32, const u32);
 #endif
 
+#if CUDA_VERSION >= 9000
+#undef __shfl
+#undef __any
+#define __shfl(a, b) __shfl_sync(0xFFFFFFFF, a, b)
+#define __any(a) __any_sync(0xFFFFFFFF, a)
+#endif
+
 typedef u32 proof[PROOFSIZE];
 
 struct __align__(32) slot {

--- a/lyra2/cuda_lyra2.cu
+++ b/lyra2/cuda_lyra2.cu
@@ -25,6 +25,12 @@
 __device__ uint32_t __shfl(uint32_t a, uint32_t b, uint32_t c);
 #endif
 
+#if CUDA_VERSION >= 9000
+#undef __shfl
+#define __shfl(a, b, c) __shfl_sync(0xFFFFFFFF, a, b, c)
+#endif
+
+
 #define Nrow 8
 #define Ncol 8
 #define memshift 3

--- a/lyra2/cuda_lyra2Z.cu
+++ b/lyra2/cuda_lyra2Z.cu
@@ -277,6 +277,11 @@ __global__ void lyra2Z_gpu_hash_32_sm2(uint32_t threads, uint32_t startNounce, u
 #include "cuda_lyra2_vectors.h"
 //#include "cuda_vector_uint2x4.h"
 
+#if CUDA_VERSION >= 9000
+#undef __shfl
+#define __shfl(a, b, c) __shfl_sync(0xFFFFFFFF, a, b, c)
+#endif
+
 #define Nrow 8
 #define Ncol 8
 #define memshift 3

--- a/lyra2/cuda_lyra2_vectors.h
+++ b/lyra2/cuda_lyra2_vectors.h
@@ -20,6 +20,11 @@
 #define __ldg4(x) (*(x))
 #endif
 
+#if CUDA_VERSION >= 9000
+#undef __shfl
+#define __shfl(a, b) __shfl_sync(0xFFFFFFFF, a, b)
+#endif
+
 typedef struct __align__(32) uint8 {
 	unsigned int s0, s1, s2, s3, s4, s5, s6, s7;
 } uint8;

--- a/lyra2/cuda_lyra2v2.cu
+++ b/lyra2/cuda_lyra2v2.cu
@@ -14,11 +14,21 @@
 #define __CUDA_ARCH__ 500
 #endif
 
+#if CUDA_VERSION >= 9000
+#undef __shfl
+#define __shfl(a, b, c) __shfl_sync(0xFFFFFFFF, a, b, c)
+#endif
+
 #define TPB 32
 
 #if __CUDA_ARCH__ >= 500
 
 #include "cuda_lyra2_vectors.h"
+
+#if CUDA_VERSION >= 9000
+#undef __shfl
+#define __shfl(a, b, c) __shfl_sync(0xFFFFFFFF, a, b, c)
+#endif
 
 #define Nrow 4
 #define Ncol 4

--- a/neoscrypt/cuda_neoscrypt.cu
+++ b/neoscrypt/cuda_neoscrypt.cu
@@ -19,6 +19,11 @@ typedef uint48 uint4x2;
 #define atomicExch(p,x) x
 #endif
 
+#if CUDA_VERSION >= 9000
+#undef __shfl
+#define __shfl(a, b, c) __shfl_sync(0xFFFFFFFF, a, b, c)
+#endif
+
 static uint32_t* d_NNonce[MAX_GPUS];
 
 __device__ uint2x4* W;

--- a/quark/cuda_quark_compactionTest.cu
+++ b/quark/cuda_quark_compactionTest.cu
@@ -14,6 +14,11 @@
 #define __shfl_up(var, delta, width) (0)
 #endif
 
+#if CUDA_VERSION >= 9000
+#undef __shfl_up
+#define __shfl_up(var, delta, width) __shfl_up_sync(0xFFFFFFFF, var, delta, width)
+#endif
+
 static uint32_t *h_numValid[MAX_GPUS];
 static uint32_t *d_tempBranch1Nonces[MAX_GPUS];
 static uint32_t *d_partSum[2][MAX_GPUS]; // für bis zu vier partielle Summen

--- a/quark/groestl_functions_quad.h
+++ b/quark/groestl_functions_quad.h
@@ -271,6 +271,11 @@ void G256_ShiftBytesQ_quad(uint32_t &x7, uint32_t &x6, uint32_t &x5, uint32_t &x
 #define __shfl(var, srcLane, width) (uint32_t)(var)
 #endif
 
+#if CUDA_VERSION >= 9000
+#undef __shfl
+#define __shfl(var, srcLane, width)  __shfl_sync(0xFFFFFFFF, var, srcLane, width)
+#endif 
+
 __device__ __forceinline__
 void G256_MixFunction_quad(uint32_t *r)
 {

--- a/scrypt/kepler_kernel.cu
+++ b/scrypt/kepler_kernel.cu
@@ -10,6 +10,7 @@
 #include <map>
 
 #include <cuda_runtime.h>
+#include "cuda_helper.h"
 #include "miner.h"
 
 #include "salsa_kernel.h"
@@ -59,10 +60,17 @@ static __host__ __device__ uint4& operator += (uint4& left, const uint4& right) 
 
 static __device__ uint4 __shfl(const uint4 bx, int target_thread) {
 	return make_uint4(
-		__shfl((int)bx.x, target_thread),
+#if CUDA_VERSION < 9000
+        __shfl((int)bx.x, target_thread),
 		__shfl((int)bx.y, target_thread),
 		__shfl((int)bx.z, target_thread),
 		__shfl((int)bx.w, target_thread)
+#else
+        __shfl_sync(0xFFFFFFFF, (int)bx.x, target_thread),
+        __shfl_sync(0xFFFFFFFF, (int)bx.y, target_thread),
+        __shfl_sync(0xFFFFFFFF, (int)bx.z, target_thread),
+        __shfl_sync(0xFFFFFFFF, (int)bx.w, target_thread)
+#endif
 	);
 }
 
@@ -97,8 +105,13 @@ void write_keys_direct(const uint4 &b, const uint4 &bx, uint32_t start)
 
 	if (SCHEME == ANDERSEN) {
 		int target_thread = (threadIdx.x + 4)%32;
-		uint4 t=b, t2=__shfl(bx, target_thread);
+#if CUDA_VERSION < 9000
+        uint4 t=b, t2=__shfl(bx, target_thread);
 		int t2_start = __shfl((int)start, target_thread) + 4;
+#else
+        uint4 t=b, t2=__shfl( bx, target_thread);
+        int t2_start = __shfl_sync(0xFFFFFFFF, (int)start, target_thread) + 4;
+#endif
 		bool c = (threadIdx.x & 0x4);
 		*((uint4 *)(&scratch[c ? t2_start : start])) = (c ? t2 : t);
 		*((uint4 *)(&scratch[c ? start : t2_start])) = (c ? t : t2);
@@ -115,7 +128,11 @@ void read_keys_direct(uint4 &b, uint4 &bx, uint32_t start)
 
 	if (TEX_DIM == 0) scratch = c_V[(blockIdx.x*blockDim.x + threadIdx.x)/32];
 	if (SCHEME == ANDERSEN) {
+#if CUDA_VERSION < 9000
 		int t2_start = __shfl((int)start, (threadIdx.x + 4)%32) + 4;
+#else
+        int t2_start = __shfl_sync(0xFFFFFFFF, (int)start, (threadIdx.x + 4)%32) + 4;
+#endif
 		if (TEX_DIM > 0) { start /= 4; t2_start /= 4; }
 		bool c = (threadIdx.x & 0x4);
 		if (TEX_DIM == 0) {
@@ -129,7 +146,11 @@ void read_keys_direct(uint4 &b, uint4 &bx, uint32_t start)
 				bx = tex2D(texRef2D_4_V, 0.5f + ((c ? start : t2_start)%TEXWIDTH), 0.5f + ((c ? start : t2_start)/TEXWIDTH));
 		}
 		uint4 tmp = b; b = (c ? bx : b); bx = (c ? tmp : bx);
+#if CUDA_VERSION < 9000
 		bx = __shfl(bx, (threadIdx.x + 28)%32);
+#else
+        bx = __shfl(bx, (threadIdx.x + 28)%32);
+#endif
 	} else {
 				 if (TEX_DIM == 0) b = *((uint4 *)(&scratch[start]));
 		else if (TEX_DIM == 1) b = tex1Dfetch(texRef1D_4_V, start/4);
@@ -149,14 +170,26 @@ void primary_order_shuffle(uint4 &b, uint4 &bx)
 	int x2 = (threadIdx.x & 0x1c) + (((threadIdx.x & 0x03)+2)&0x3);
 	int x3 = (threadIdx.x & 0x1c) + (((threadIdx.x & 0x03)+3)&0x3);
 
+#if CUDA_VERSION < 9000
 	b.w = __shfl((int)b.w, x1);
 	b.z = __shfl((int)b.z, x2);
 	b.y = __shfl((int)b.y, x3);
+#else
+    b.w = __shfl_sync(0xFFFFFFFF, (int)b.w, x1);
+    b.z = __shfl_sync(0xFFFFFFFF, (int)b.z, x2);
+    b.y = __shfl_sync(0xFFFFFFFF, (int)b.y, x3);
+#endif
 	uint32_t tmp = b.y; b.y = b.w; b.w = tmp;
 
+#if CUDA_VERSION < 9000
 	bx.w = __shfl((int)bx.w, x1);
 	bx.z = __shfl((int)bx.z, x2);
 	bx.y = __shfl((int)bx.y, x3);
+#else
+    bx.w = __shfl_sync(0xFFFFFFFF, (int)bx.w, x1);
+    bx.z = __shfl_sync(0xFFFFFFFF, (int)bx.z, x2);
+    bx.y = __shfl_sync(0xFFFFFFFF, (int)bx.y, x3);
+#endif
 	tmp = bx.y; bx.y = bx.w; bx.w = tmp;
 }
 
@@ -318,10 +351,15 @@ void salsa_xor_core(uint4 &b, uint4 &bx, const int x1, const int x2, const int x
 		/* Unclear if this optimization is needed: These are ordered based
 		 * upon the dependencies needed in the later xors. Compiler should be
 		 * able to figure this out, but might as well give it a hand. */
-		x.y = __shfl((int)x.y, x3);
+#if CUDA_VERSION < 9000
+        x.y = __shfl((int)x.y, x3);
 		x.w = __shfl((int)x.w, x1);
 		x.z = __shfl((int)x.z, x2);
-
+#else
+        x.y = __shfl_sync(0xFFFFFFFF, (int)x.y, x3);
+        x.w = __shfl_sync(0xFFFFFFFF, (int)x.w, x1);
+        x.z = __shfl_sync(0xFFFFFFFF, (int)x.z, x2);
+#endif
 		/* The next XOR_ROTATE_ADDS could be written to be a copy-paste of the first,
 		 * but the register targets are rewritten here to swap x[1] and x[3] so that
 		 * they can be directly shuffled to and from our peer threads without
@@ -333,9 +371,15 @@ void salsa_xor_core(uint4 &b, uint4 &bx, const int x1, const int x2, const int x
 		XOR_ROTATE_ADD(x.y, x.z, x.w, 13);
 		XOR_ROTATE_ADD(x.x, x.y, x.z, 18);
 
+#if CUDA_VERSION < 9000
 		x.w = __shfl((int)x.w, x3);
 		x.y = __shfl((int)x.y, x1);
 		x.z = __shfl((int)x.z, x2);
+#else
+        x.w = __shfl_sync(0xFFFFFFFF, (int)x.w, x3);
+        x.y = __shfl_sync(0xFFFFFFFF, (int)x.y, x1);
+        x.z = __shfl_sync(0xFFFFFFFF, (int)x.z, x2);
+#endif
 	}
 
 	b += x;
@@ -352,18 +396,30 @@ void salsa_xor_core(uint4 &b, uint4 &bx, const int x1, const int x2, const int x
 		XOR_ROTATE_ADD(x.w, x.z, x.y, 13);
 		XOR_ROTATE_ADD(x.x, x.w, x.z, 18);
 
+#if CUDA_VERSION < 9000
 		x.y = __shfl((int)x.y, x3);
 		x.w = __shfl((int)x.w, x1);
 		x.z = __shfl((int)x.z, x2);
+#else
+        x.y = __shfl_sync(0xFFFFFFFF, (int)x.y, x3);
+        x.w = __shfl_sync(0xFFFFFFFF, (int)x.w, x1);
+        x.z = __shfl_sync(0xFFFFFFFF, (int)x.z, x2);
+#endif
 
 		XOR_ROTATE_ADD(x.w, x.x, x.y, 7);
 		XOR_ROTATE_ADD(x.z, x.w, x.x, 9);
 		XOR_ROTATE_ADD(x.y, x.z, x.w, 13);
 		XOR_ROTATE_ADD(x.x, x.y, x.z, 18);
 
+#if CUDA_VERSION < 9000
 		x.w = __shfl((int)x.w, x3);
 		x.y = __shfl((int)x.y, x1);
 		x.z = __shfl((int)x.z, x2);
+#else
+        x.w = __shfl_sync(0xFFFFFFFF, (int)x.w, x3);
+        x.y = __shfl_sync(0xFFFFFFFF, (int)x.y, x1);
+        x.z = __shfl_sync(0xFFFFFFFF, (int)x.z, x2);
+#endif
 	}
 
 	// At the end of these iterations, the data is in primary order again.
@@ -407,9 +463,15 @@ void chacha_xor_core(uint4 &b, uint4 &bx, const int x1, const int x2, const int 
 		CHACHA_PRIMITIVE(x.x ,x.w, x.y,  8)
 		CHACHA_PRIMITIVE(x.z ,x.y, x.w,  7)
 
+#if CUDA_VERSION < 9000
 		x.y = __shfl((int)x.y, x1);
 		x.z = __shfl((int)x.z, x2);
 		x.w = __shfl((int)x.w, x3);
+#else
+        x.y = __shfl_sync(0xFFFFFFFF, (int)x.y, x1);
+        x.z = __shfl_sync(0xFFFFFFFF, (int)x.z, x2);
+        x.w = __shfl_sync(0xFFFFFFFF, (int)x.w, x3);
+#endif
 
 		// Diagonal Mixing phase of chacha
 		CHACHA_PRIMITIVE(x.x ,x.w, x.y, 16)
@@ -417,9 +479,15 @@ void chacha_xor_core(uint4 &b, uint4 &bx, const int x1, const int x2, const int 
 		CHACHA_PRIMITIVE(x.x ,x.w, x.y,  8)
 		CHACHA_PRIMITIVE(x.z ,x.y, x.w,  7)
 
+#if CUDA_VERSION < 9000
 		x.y = __shfl((int)x.y, x3);
 		x.z = __shfl((int)x.z, x2);
 		x.w = __shfl((int)x.w, x1);
+#else
+        x.y = __shfl_sync(0xFFFFFFFF, (int)x.y, x3);
+        x.z = __shfl_sync(0xFFFFFFFF, (int)x.z, x2);
+        x.w = __shfl_sync(0xFFFFFFFF, (int)x.w, x1);
+#endif
 	}
 
 	b += x;
@@ -436,19 +504,30 @@ void chacha_xor_core(uint4 &b, uint4 &bx, const int x1, const int x2, const int 
 		CHACHA_PRIMITIVE(x.x ,x.w, x.y,  8)
 		CHACHA_PRIMITIVE(x.z ,x.y, x.w,  7)
 
+#if CUDA_VERSION < 9000
 		x.y = __shfl((int)x.y, x1);
 		x.z = __shfl((int)x.z, x2);
 		x.w = __shfl((int)x.w, x3);
-
+#else
+        x.y = __shfl_sync(0xFFFFFFFF, (int)x.y, x1);
+        x.z = __shfl_sync(0xFFFFFFFF, (int)x.z, x2);
+        x.w = __shfl_sync(0xFFFFFFFF, (int)x.w, x3);
+#endif
 		// Diagonal Mixing phase of chacha
 		CHACHA_PRIMITIVE(x.x ,x.w, x.y, 16)
 		CHACHA_PRIMITIVE(x.z ,x.y, x.w, 12)
 		CHACHA_PRIMITIVE(x.x ,x.w, x.y,  8)
 		CHACHA_PRIMITIVE(x.z ,x.y, x.w,  7)
 
+#if CUDA_VERSION < 9000
 		x.y = __shfl((int)x.y, x3);
 		x.z = __shfl((int)x.z, x2);
 		x.w = __shfl((int)x.w, x1);
+#else
+        x.y = __shfl_sync(0xFFFFFFFF, (int)x.y, x3);
+        x.z = __shfl_sync(0xFFFFFFFF, (int)x.z, x2);
+        x.w = __shfl_sync(0xFFFFFFFF, (int)x.w, x1);
+#endif
 	}
 
 #undef CHACHA_PRIMITIVE
@@ -572,7 +651,11 @@ void kepler_scrypt_core_kernelB(uint32_t *d_odata, int begin, int end)
 	} else load_key<ALGO>(d_odata, b, bx);
 
 	for (int i = begin; i < end; i++) {
-		int j = (__shfl((int)bx.x, (threadIdx.x & 0x1c)) & (c_N_1));
+#if CUDA_VERSION < 9000
+        int j = (__shfl((int)bx.x, (threadIdx.x & 0x1c)) & (c_N_1));
+#else
+        int j = (__shfl_sync(0xFFFFFFFF, (int)bx.x, (threadIdx.x & 0x1c)) & (c_N_1));
+#endif
 		uint4 t, tx; read_keys_direct<SCHEME, TEX_DIM>(t, tx, start+32*j);
 		b ^= t; bx ^= tx;
 		block_mixer<ALGO>(b, bx, x1, x2, x3);
@@ -604,7 +687,11 @@ void kepler_scrypt_core_kernelB_LG(uint32_t *d_odata, int begin, int end, unsign
 	{
 		// better divergent thread handling submitted by nVidia engineers, but
 		// supposedly this does not run with the ANDERSEN memory access scheme
-		int j = (__shfl((int)bx.x, (threadIdx.x & 0x1c)) & (c_N_1));
+#if CUDA_VERSION < 9000
+        int j = (__shfl((int)bx.x, (threadIdx.x & 0x1c)) & (c_N_1));
+#else
+        int j = (__shfl_sync(0xFFFFFFFF, (int)bx.x, (threadIdx.x & 0x1c)) & (c_N_1));
+#endif
 		int pos = j/LOOKUP_GAP;
 		int loop = -1;
 		uint4 t, tx;
@@ -612,7 +699,11 @@ void kepler_scrypt_core_kernelB_LG(uint32_t *d_odata, int begin, int end, unsign
 		int i = begin;
 		while(i < end) {
 			if (loop==-1) {
+#if CUDA_VERSION < 9000
 				j = (__shfl((int)bx.x, (threadIdx.x & 0x1c)) & (c_N_1));
+#else
+                j = (__shfl_sync(0xFFFFFFFF, (int)bx.x, (threadIdx.x & 0x1c)) & (c_N_1));
+#endif
 				pos = j/LOOKUP_GAP;
 				loop = j-pos*LOOKUP_GAP;
 				read_keys_direct<SCHEME,TEX_DIM>(t, tx, start+32*pos);
@@ -634,7 +725,11 @@ void kepler_scrypt_core_kernelB_LG(uint32_t *d_odata, int begin, int end, unsign
 		// this is my original implementation, now used with the ANDERSEN
 		// memory access scheme only.
 		for (int i = begin; i < end; i++) {
+#if CUDA_VERSION < 9000
 			int j = (__shfl((int)bx.x, (threadIdx.x & 0x1c)) & (c_N_1));
+#else
+            int j = (__shfl_sync(0xFFFFFFFF, (int)bx.x, (threadIdx.x & 0x1c)) & (c_N_1));
+#endif
 			int pos = j/LOOKUP_GAP, loop = j-pos*LOOKUP_GAP;
 			uint4 t, tx; read_keys_direct<SCHEME,TEX_DIM>(t, tx, start+32*pos);
 			while(loop--) block_mixer<ALGO>(t, tx, x1, x2, x3);

--- a/scrypt/nv_kernel.cu
+++ b/scrypt/nv_kernel.cu
@@ -217,7 +217,6 @@ __device__ __forceinline__ void __transposed_write_BC(uint4 (&B)[4], uint4 (&C)[
 
 	// rotate rows
 	T1[0] = B[0];
-#if 1 //CUDA_VERSION < 9000
 	T1[1] = __shfl(B[1], lane8 + 7, 8);
 	T1[2] = __shfl(B[2], lane8 + 6, 8);
 	T1[3] = __shfl(B[3], lane8 + 5, 8);
@@ -225,15 +224,6 @@ __device__ __forceinline__ void __transposed_write_BC(uint4 (&B)[4], uint4 (&C)[
 	T1[5] = __shfl(C[1], lane8 + 3, 8);
 	T1[6] = __shfl(C[2], lane8 + 2, 8);
 	T1[7] = __shfl(C[3], lane8 + 1, 8);
-#else
-    T1[1] = __shfl_sync(0xFFFFFFFF, B[1], lane8 + 7, 8);
-    T1[2] = __shfl_sync(0xFFFFFFFF, B[2], lane8 + 6, 8);
-    T1[3] = __shfl_sync(0xFFFFFFFF, B[3], lane8 + 5, 8);
-    T1[4] = __shfl_sync(0xFFFFFFFF, C[0], lane8 + 4, 8);
-    T1[5] = __shfl_sync(0xFFFFFFFF, C[1], lane8 + 3, 8);
-    T1[6] = __shfl_sync(0xFFFFFFFF, C[2], lane8 + 2, 8);
-    T1[7] = __shfl_sync(0xFFFFFFFF, C[3], lane8 + 1, 8);
-#endif
 
 	/* Matrix after row rotates:
 
@@ -292,62 +282,42 @@ template <int TEX_DIM> __device__ __forceinline__ void __transposed_read_BC(cons
 	// read and rotate rows, in reverse row order
 	uint4 T1[8], T2[8];
 	const uint4 *loc;
-	loc = &S[(spacing*2*(32*tile   ) +  lane8      + 8*
-#if CUDA_VERSION < 9000 
-            __shfl(row, 0, 8))];
-#else
-            __shfl_sync(0xFFFFFFFF, row, 0, 8))];
-#endif
+
+#if CUDA_VERSION < 9000
+	loc = &S[(spacing*2*(32*tile   ) +  lane8      + 8*__shfl(row, 0, 8))];
 	T1[7] = TEX_DIM==0 ? __ldg(loc) : TEX_DIM==1 ? tex1Dfetch(texRef1D_4_V, loc-(uint4*)c_V[0]) : tex2D(texRef2D_4_V, 0.5f + ((loc-(uint4*)c_V[0])%TEXWIDTH), 0.5f + ((loc-(uint4*)c_V[0])/TEXWIDTH));
-	loc = &S[(spacing*2*(32*tile+4 ) + (lane8+7)%8 + 8*
-#if CUDA_VERSION < 9000
-            __shfl(row, 1, 8))];
-#else
-            __shfl_sync(0xFFFFFFFF, row, 1, 8))];
-#endif
+	loc = &S[(spacing*2*(32*tile+4 ) + (lane8+7)%8 + 8*__shfl(row, 1, 8))];
 	T1[6] = TEX_DIM==0 ? __ldg(loc) : TEX_DIM==1 ? tex1Dfetch(texRef1D_4_V, loc-(uint4*)c_V[0]) : tex2D(texRef2D_4_V, 0.5f + ((loc-(uint4*)c_V[0])%TEXWIDTH), 0.5f + ((loc-(uint4*)c_V[0])/TEXWIDTH));
-	loc = &S[(spacing*2*(32*tile+8 ) + (lane8+6)%8 + 8*
-#if CUDA_VERSION < 9000
-            __shfl(row, 2, 8))];
-#else
-            __shfl_sync(0xFFFFFFFF, row, 2, 8))];
-#endif
+	loc = &S[(spacing*2*(32*tile+8 ) + (lane8+6)%8 + 8*__shfl(row, 2, 8))];
 	T1[5] = TEX_DIM==0 ? __ldg(loc) : TEX_DIM==1 ? tex1Dfetch(texRef1D_4_V, loc-(uint4*)c_V[0]) : tex2D(texRef2D_4_V, 0.5f + ((loc-(uint4*)c_V[0])%TEXWIDTH), 0.5f + ((loc-(uint4*)c_V[0])/TEXWIDTH));
-	loc = &S[(spacing*2*(32*tile+12) + (lane8+5)%8 + 8*
-#if CUDA_VERSION < 9000
-            __shfl(row, 3, 8))];
-#else
-            __shfl_sync(0xFFFFFFFF, row, 3, 8))];
-#endif
+	loc = &S[(spacing*2*(32*tile+12) + (lane8+5)%8 + 8*__shfl(row, 3, 8))];
 	T1[4] = TEX_DIM==0 ? __ldg(loc) : TEX_DIM==1 ? tex1Dfetch(texRef1D_4_V, loc-(uint4*)c_V[0]) : tex2D(texRef2D_4_V, 0.5f + ((loc-(uint4*)c_V[0])%TEXWIDTH), 0.5f + ((loc-(uint4*)c_V[0])/TEXWIDTH));
-	loc = &S[(spacing*2*(32*tile+16) + (lane8+4)%8 + 8*
-#if CUDA_VERSION < 9000
-            __shfl(row, 4, 8))];
-#else
-            __shfl_sync(0xFFFFFFFF, row, 4, 8))];
-#endif
+	loc = &S[(spacing*2*(32*tile+16) + (lane8+4)%8 + 8*__shfl(row, 4, 8))];
 	T1[3] = TEX_DIM==0 ? __ldg(loc) : TEX_DIM==1 ? tex1Dfetch(texRef1D_4_V, loc-(uint4*)c_V[0]) : tex2D(texRef2D_4_V, 0.5f + ((loc-(uint4*)c_V[0])%TEXWIDTH), 0.5f + ((loc-(uint4*)c_V[0])/TEXWIDTH));
-	loc = &S[(spacing*2*(32*tile+20) + (lane8+3)%8 + 8*
-#if CUDA_VERSION < 9000
-            __shfl(row, 5, 8))];
-#else
-            __shfl_sync(0xFFFFFFFF, row, 5, 8))];
-#endif
+	loc = &S[(spacing*2*(32*tile+20) + (lane8+3)%8 + 8*__shfl(row, 5, 8))];
 	T1[2] = TEX_DIM==0 ? __ldg(loc) : TEX_DIM==1 ? tex1Dfetch(texRef1D_4_V, loc-(uint4*)c_V[0]) : tex2D(texRef2D_4_V, 0.5f + ((loc-(uint4*)c_V[0])%TEXWIDTH), 0.5f + ((loc-(uint4*)c_V[0])/TEXWIDTH));
-	loc = &S[(spacing*2*(32*tile+24) + (lane8+2)%8 + 8*
-#if CUDA_VERSION < 9000
-            __shfl(row, 6, 8))];
-#else
-            __shfl_sync(0xFFFFFFFF, row, 6, 8))];
-#endif
+	loc = &S[(spacing*2*(32*tile+24) + (lane8+2)%8 + 8*__shfl(row, 6, 8))];
 	T1[1] = TEX_DIM==0 ? __ldg(loc) : TEX_DIM==1 ? tex1Dfetch(texRef1D_4_V, loc-(uint4*)c_V[0]) : tex2D(texRef2D_4_V, 0.5f + ((loc-(uint4*)c_V[0])%TEXWIDTH), 0.5f + ((loc-(uint4*)c_V[0])/TEXWIDTH));
-	loc = &S[(spacing*2*(32*tile+28) + (lane8+1)%8 + 8*
-#if CUDA_VERSION < 9000
-            __shfl(row, 7, 8))];
-#else
-            __shfl_sync(0xFFFFFFFF, row, 7, 8))];
-#endif
+	loc = &S[(spacing*2*(32*tile+28) + (lane8+1)%8 + 8*__shfl(row, 7, 8))];
 	T1[0] = TEX_DIM==0 ? __ldg(loc) : TEX_DIM==1 ? tex1Dfetch(texRef1D_4_V, loc-(uint4*)c_V[0]) : tex2D(texRef2D_4_V, 0.5f + ((loc-(uint4*)c_V[0])%TEXWIDTH), 0.5f + ((loc-(uint4*)c_V[0])/TEXWIDTH));
+#else
+	loc = &S[(spacing*2*(32*tile   ) +  lane8      + 8*__shfl_sync(0xFFFFFFFF, row, 0, 8))];
+	T1[7] = TEX_DIM==0 ? __ldg(loc) : TEX_DIM==1 ? tex1Dfetch(texRef1D_4_V, loc-(uint4*)c_V[0]) : tex2D(texRef2D_4_V, 0.5f + ((loc-(uint4*)c_V[0])%TEXWIDTH), 0.5f + ((loc-(uint4*)c_V[0])/TEXWIDTH));
+	loc = &S[(spacing*2*(32*tile+4 ) + (lane8+7)%8 + 8*__shfl_sync(0xFFFFFFFF, row, 1, 8))];
+	T1[6] = TEX_DIM==0 ? __ldg(loc) : TEX_DIM==1 ? tex1Dfetch(texRef1D_4_V, loc-(uint4*)c_V[0]) : tex2D(texRef2D_4_V, 0.5f + ((loc-(uint4*)c_V[0])%TEXWIDTH), 0.5f + ((loc-(uint4*)c_V[0])/TEXWIDTH));
+	loc = &S[(spacing*2*(32*tile+8 ) + (lane8+6)%8 + 8*__shfl_sync(0xFFFFFFFF, row, 2, 8))];
+	T1[5] = TEX_DIM==0 ? __ldg(loc) : TEX_DIM==1 ? tex1Dfetch(texRef1D_4_V, loc-(uint4*)c_V[0]) : tex2D(texRef2D_4_V, 0.5f + ((loc-(uint4*)c_V[0])%TEXWIDTH), 0.5f + ((loc-(uint4*)c_V[0])/TEXWIDTH));
+	loc = &S[(spacing*2*(32*tile+12) + (lane8+5)%8 + 8*__shfl_sync(0xFFFFFFFF, row, 3, 8))];
+	T1[4] = TEX_DIM==0 ? __ldg(loc) : TEX_DIM==1 ? tex1Dfetch(texRef1D_4_V, loc-(uint4*)c_V[0]) : tex2D(texRef2D_4_V, 0.5f + ((loc-(uint4*)c_V[0])%TEXWIDTH), 0.5f + ((loc-(uint4*)c_V[0])/TEXWIDTH));
+	loc = &S[(spacing*2*(32*tile+16) + (lane8+4)%8 + 8*__shfl_sync(0xFFFFFFFF, row, 4, 8))];
+	T1[3] = TEX_DIM==0 ? __ldg(loc) : TEX_DIM==1 ? tex1Dfetch(texRef1D_4_V, loc-(uint4*)c_V[0]) : tex2D(texRef2D_4_V, 0.5f + ((loc-(uint4*)c_V[0])%TEXWIDTH), 0.5f + ((loc-(uint4*)c_V[0])/TEXWIDTH));
+	loc = &S[(spacing*2*(32*tile+20) + (lane8+3)%8 + 8*__shfl_sync(0xFFFFFFFF, row, 5, 8))];
+	T1[2] = TEX_DIM==0 ? __ldg(loc) : TEX_DIM==1 ? tex1Dfetch(texRef1D_4_V, loc-(uint4*)c_V[0]) : tex2D(texRef2D_4_V, 0.5f + ((loc-(uint4*)c_V[0])%TEXWIDTH), 0.5f + ((loc-(uint4*)c_V[0])/TEXWIDTH));
+	loc = &S[(spacing*2*(32*tile+24) + (lane8+2)%8 + 8*__shfl_sync(0xFFFFFFFF, row, 6, 8))];
+	T1[1] = TEX_DIM==0 ? __ldg(loc) : TEX_DIM==1 ? tex1Dfetch(texRef1D_4_V, loc-(uint4*)c_V[0]) : tex2D(texRef2D_4_V, 0.5f + ((loc-(uint4*)c_V[0])%TEXWIDTH), 0.5f + ((loc-(uint4*)c_V[0])/TEXWIDTH));
+	loc = &S[(spacing*2*(32*tile+28) + (lane8+1)%8 + 8*__shfl_sync(0xFFFFFFFF, row, 7, 8))];
+	T1[0] = TEX_DIM==0 ? __ldg(loc) : TEX_DIM==1 ? tex1Dfetch(texRef1D_4_V, loc-(uint4*)c_V[0]) : tex2D(texRef2D_4_V, 0.5f + ((loc-(uint4*)c_V[0])%TEXWIDTH), 0.5f + ((loc-(uint4*)c_V[0])/TEXWIDTH));
+#endif
 
 	// rotate columns down using a barrel shifter simulation
 	// column X is rotated down by (X+1) items, or up by (8-(X+1)) = (7-X) items
@@ -360,7 +330,6 @@ template <int TEX_DIM> __device__ __forceinline__ void __transposed_read_BC(cons
 
 	// rotate rows
 	B[0] = T2[0];
-#if 1 //CUDA_VERSION < 9000
 	B[1] = __shfl(T2[1], lane8 + 1, 8);
 	B[2] = __shfl(T2[2], lane8 + 2, 8);
 	B[3] = __shfl(T2[3], lane8 + 3, 8);
@@ -368,15 +337,6 @@ template <int TEX_DIM> __device__ __forceinline__ void __transposed_read_BC(cons
 	C[1] = __shfl(T2[5], lane8 + 5, 8);
 	C[2] = __shfl(T2[6], lane8 + 6, 8);
 	C[3] = __shfl(T2[7], lane8 + 7, 8);
-#else
-    B[1] = __shfl_sync(0xFFFFFFFF, T2[1], lane8 + 1, 8);
-    B[2] = __shfl_sync(0xFFFFFFFF, T2[2], lane8 + 2, 8);
-    B[3] = __shfl_sync(0xFFFFFFFF, T2[3], lane8 + 3, 8);
-    C[0] = __shfl_sync(0xFFFFFFFF, T2[4], lane8 + 4, 8);
-    C[1] = __shfl_sync(0xFFFFFFFF, T2[5], lane8 + 5, 8);
-    C[2] = __shfl_sync(0xFFFFFFFF, T2[6], lane8 + 6, 8);
-    C[3] = __shfl_sync(0xFFFFFFFF, T2[7], lane8 + 7, 8);
-#endif
 }
 
 template <int TEX_DIM> __device__ __forceinline__ void __transposed_xor_BC(const uint4 *S, uint4 (&B)[4], uint4 (&C)[4], int spacing, int row)

--- a/scrypt/nv_kernel2.cu
+++ b/scrypt/nv_kernel2.cu
@@ -252,7 +252,6 @@ __device__ __forceinline__ void __transposed_read_BC(const uint4 *S, uint4 (&B)[
 
 	// rotate rows
 	B[0] = T2[0];
-#if 1 //CUDA_VERSION < 9000
 	B[1] = __shfl(T2[1], lane8 + 1, 8);
 	B[2] = __shfl(T2[2], lane8 + 2, 8);
 	B[3] = __shfl(T2[3], lane8 + 3, 8);
@@ -260,15 +259,6 @@ __device__ __forceinline__ void __transposed_read_BC(const uint4 *S, uint4 (&B)[
 	C[1] = __shfl(T2[5], lane8 + 5, 8);
 	C[2] = __shfl(T2[6], lane8 + 6, 8);
 	C[3] = __shfl(T2[7], lane8 + 7, 8);
-#else
-	B[1] = __shfl_sync(0xFFFFFFFF, T2[1], lane8 + 1, 8);
-	B[2] = __shfl_sync(0xFFFFFFFF, T2[2], lane8 + 2, 8);
-	B[3] = __shfl_sync(0xFFFFFFFF, T2[3], lane8 + 3, 8);
-	C[0] = __shfl_sync(0xFFFFFFFF, T2[4], lane8 + 4, 8);
-	C[1] = __shfl_sync(0xFFFFFFFF, T2[5], lane8 + 5, 8);
-	C[2] = __shfl_sync(0xFFFFFFFF, T2[6], lane8 + 6, 8);
-	C[3] = __shfl_sync(0xFFFFFFFF, T2[7], lane8 + 7, 8);
-#endif
 }
 
 __device__ __forceinline__ void __transposed_xor_BC(const uint4 *S, uint4 (&B)[4], uint4 (&C)[4], int spacing, int row)

--- a/scrypt/titan_kernel.cu
+++ b/scrypt/titan_kernel.cu
@@ -10,6 +10,7 @@
 #include <map>
 
 #include <cuda_runtime.h>
+#include "cuda_helper.h"
 #include "miner.h"
 
 #include "salsa_kernel.h"
@@ -60,7 +61,19 @@ static __host__ __device__ uint4& operator += (uint4& left, const uint4& right) 
 }
 
 static __device__ uint4 __shfl(const uint4 bx, int target_thread) {
-	return make_uint4(__shfl((int)bx.x, target_thread), __shfl((int)bx.y, target_thread), __shfl((int)bx.z, target_thread), __shfl((int)bx.w, target_thread));
+	return make_uint4(
+#if CUDA_VERSION < 9000
+            __shfl((int)bx.x, target_thread), 
+            __shfl((int)bx.y, target_thread), 
+            __shfl((int)bx.z, target_thread), 
+            __shfl((int)bx.w, target_thread)
+#else
+            __shfl_sync(0xFFFFFFFF, (int)bx.x, target_thread), 
+            __shfl_sync(0xFFFFFFFF, (int)bx.y, target_thread), 
+            __shfl_sync(0xFFFFFFFF, (int)bx.z, target_thread), 
+            __shfl_sync(0xFFFFFFFF, (int)bx.w, target_thread)
+#endif
+            );
 }
 
 /* write_keys writes the 8 keys being processed by a warp to the global
@@ -94,7 +107,11 @@ void write_keys_direct(const uint4 &b, const uint4 &bx, uint32_t start)
 	if (SCHEME == ANDERSEN) {
 		int target_thread = (threadIdx.x + 4)&31;
 		uint4 t=b, t2=__shfl(bx, target_thread);
+#if CUDA_VERSION < 9000
 		int t2_start = __shfl((int)start, target_thread) + 4;
+#else
+        int t2_start = __shfl_sync(0xFFFFFFFF, (int)start, target_thread) + 4;
+#endif
 		bool c = (threadIdx.x & 0x4);
 		*((uint4 *)(&scratch[c ? t2_start : start])) = (c ? t2 : t);
 		*((uint4 *)(&scratch[c ? start : t2_start])) = (c ? t : t2);
@@ -109,7 +126,11 @@ void read_keys_direct(uint4 &b, uint4 &bx, uint32_t start)
 {
 	uint32_t *scratch = c_V[(blockIdx.x*blockDim.x + threadIdx.x)/32];
 	if (SCHEME == ANDERSEN) {
-		int t2_start = __shfl((int)start, (threadIdx.x + 4)&31) + 4;
+#if CUDA_VERSION < 9000
+        int t2_start = __shfl((int)start, (threadIdx.x + 4)&31) + 4;
+#else
+        int t2_start = __shfl_sync(0xFFFFFFFF, (int)start, (threadIdx.x + 4)&31) + 4;
+#endif
 		bool c = (threadIdx.x & 0x4);
 		b  = __ldg((uint4 *)(&scratch[c ? t2_start : start]));
 		bx = __ldg((uint4 *)(&scratch[c ? start : t2_start]));
@@ -128,14 +149,26 @@ void primary_order_shuffle(uint32_t b[4], uint32_t bx[4]) {
 	int x2 = (threadIdx.x & 0xfc) + (((threadIdx.x & 3)+2)&3);
 	int x3 = (threadIdx.x & 0xfc) + (((threadIdx.x & 3)+3)&3);
 
+#if CUDA_VERSION < 9000
 	b[3] = __shfl((int)b[3], x1);
 	b[2] = __shfl((int)b[2], x2);
 	b[1] = __shfl((int)b[1], x3);
+#else
+	b[3] = __shfl_sync(0xFFFFFFFF, (int)b[3], x1);
+	b[2] = __shfl_sync(0xFFFFFFFF, (int)b[2], x2);
+	b[1] = __shfl_sync(0xFFFFFFFF, (int)b[1], x3);
+#endif
 	uint32_t tmp = b[1]; b[1] = b[3]; b[3] = tmp;
 
+#if CUDA_VERSION < 9000
 	bx[3] = __shfl((int)bx[3], x1);
 	bx[2] = __shfl((int)bx[2], x2);
 	bx[1] = __shfl((int)bx[1], x3);
+#else
+	bx[3] = __shfl_sync(0xFFFFFFFF, (int)bx[3], x1);
+	bx[2] = __shfl_sync(0xFFFFFFFF, (int)bx[2], x2);
+	bx[1] = __shfl_sync(0xFFFFFFFF, (int)bx[1], x3);
+#endif
 	tmp = bx[1]; bx[1] = bx[3]; bx[3] = tmp;
 }
 
@@ -146,14 +179,26 @@ void primary_order_shuffle(uint4 &b, uint4 &bx) {
 	int x2 = (threadIdx.x & 0x1c) + (((threadIdx.x & 3)+2)&3);
 	int x3 = (threadIdx.x & 0x1c) + (((threadIdx.x & 3)+3)&3);
 
+#if CUDA_VERSION < 9000
 	b.w = __shfl((int)b.w, x1);
 	b.z = __shfl((int)b.z, x2);
 	b.y = __shfl((int)b.y, x3);
+#else
+	b.w = __shfl_sync(0xFFFFFFFF, (int)b.w, x1);
+	b.z = __shfl_sync(0xFFFFFFFF, (int)b.z, x2);
+	b.y = __shfl_sync(0xFFFFFFFF, (int)b.y, x3);
+#endif
 	uint32_t tmp = b.y; b.y = b.w; b.w = tmp;
 
+#if CUDA_VERSION < 9000
 	bx.w = __shfl((int)bx.w, x1);
 	bx.z = __shfl((int)bx.z, x2);
 	bx.y = __shfl((int)bx.y, x3);
+#else
+	bx.w = __shfl_sync(0xFFFFFFFF, (int)bx.w, x1);
+	bx.z = __shfl_sync(0xFFFFFFFF, (int)bx.z, x2);
+	bx.y = __shfl_sync(0xFFFFFFFF, (int)bx.y, x3);
+#endif
 	tmp = bx.y; bx.y = bx.w; bx.w = tmp;
 }
 
@@ -327,10 +372,15 @@ void salsa_xor_core(uint4 &b, uint4 &bx, const int x1, const int x2, const int x
 		/* Unclear if this optimization is needed: These are ordered based
 		 * upon the dependencies needed in the later xors. Compiler should be
 		 * able to figure this out, but might as well give it a hand. */
-		x.y = __shfl((int)x.y, x3);
+#if CUDA_VERSION < 9000
+        x.y = __shfl((int)x.y, x3);
 		x.w = __shfl((int)x.w, x1);
 		x.z = __shfl((int)x.z, x2);
-
+#else
+        x.y = __shfl_sync(0xFFFFFFFF, (int)x.y, x3);
+		x.w = __shfl_sync(0xFFFFFFFF, (int)x.w, x1);
+		x.z = __shfl_sync(0xFFFFFFFF, (int)x.z, x2);
+#endif
 		/* The next XOR_ROTATE_ADDS could be written to be a copy-paste of the first,
 		 * but the register targets are rewritten here to swap x[1] and x[3] so that
 		 * they can be directly shuffled to and from our peer threads without
@@ -342,9 +392,15 @@ void salsa_xor_core(uint4 &b, uint4 &bx, const int x1, const int x2, const int x
 		XOR_ROTATE_ADD(x.y, x.z, x.w, 13);
 		XOR_ROTATE_ADD(x.x, x.y, x.z, 18);
 
+#if CUDA_VERSION < 9000
 		x.w = __shfl((int)x.w, x3);
 		x.y = __shfl((int)x.y, x1);
 		x.z = __shfl((int)x.z, x2);
+#else
+		x.w = __shfl_sync(0xFFFFFFFF, (int)x.w, x3);
+		x.y = __shfl_sync(0xFFFFFFFF, (int)x.y, x1);
+		x.z = __shfl_sync(0xFFFFFFFF, (int)x.z, x2);
+#endif
 	}
 
 	b += x;
@@ -362,18 +418,29 @@ void salsa_xor_core(uint4 &b, uint4 &bx, const int x1, const int x2, const int x
 		XOR_ROTATE_ADD(x.w, x.z, x.y, 13);
 		XOR_ROTATE_ADD(x.x, x.w, x.z, 18);
 
+#if CUDA_VERSION < 9000
 		x.y = __shfl((int)x.y, x3);
 		x.w = __shfl((int)x.w, x1);
 		x.z = __shfl((int)x.z, x2);
-
+#else
+		x.y = __shfl_sync(0xFFFFFFFF, (int)x.y, x3);
+		x.w = __shfl_sync(0xFFFFFFFF, (int)x.w, x1);
+		x.z = __shfl_sync(0xFFFFFFFF, (int)x.z, x2);
+#endif
 		XOR_ROTATE_ADD(x.w, x.x, x.y, 7);
 		XOR_ROTATE_ADD(x.z, x.w, x.x, 9);
 		XOR_ROTATE_ADD(x.y, x.z, x.w, 13);
 		XOR_ROTATE_ADD(x.x, x.y, x.z, 18);
 
+#if CUDA_VERSION < 9000
 		x.w = __shfl((int)x.w, x3);
 		x.y = __shfl((int)x.y, x1);
 		x.z = __shfl((int)x.z, x2);
+#else
+		x.w = __shfl_sync(0xFFFFFFFF, (int)x.w, x3);
+		x.y = __shfl_sync(0xFFFFFFFF, (int)x.y, x1);
+		x.z = __shfl_sync(0xFFFFFFFF, (int)x.z, x2);
+#endif
 	}
 
 	// At the end of these iterations, the data is in primary order again.
@@ -424,19 +491,30 @@ void chacha_xor_core(uint4 &b, uint4 &bx, const int x1, const int x2, const int 
 		CHACHA_PRIMITIVE(x.x ,x.w, x.y,  8)
 		CHACHA_PRIMITIVE(x.z ,x.y, x.w,  7)
 
+#if CUDA_VERSION < 9000
 		x.y = __shfl((int)x.y, x1);
 		x.z = __shfl((int)x.z, x2);
 		x.w = __shfl((int)x.w, x3);
-
+#else
+		x.y = __shfl_sync(0xFFFFFFFF, (int)x.y, x1);
+		x.z = __shfl_sync(0xFFFFFFFF, (int)x.z, x2);
+		x.w = __shfl_sync(0xFFFFFFFF, (int)x.w, x3);
+#endif
 		// Diagonal Mixing phase of chacha
 		CHACHA_PRIMITIVE(x.x ,x.w, x.y, 16)
 		CHACHA_PRIMITIVE(x.z ,x.y, x.w, 12)
 		CHACHA_PRIMITIVE(x.x ,x.w, x.y,  8)
 		CHACHA_PRIMITIVE(x.z ,x.y, x.w,  7)
 
+#if CUDA_VERSION < 9000
 		x.y = __shfl((int)x.y, x3);
 		x.z = __shfl((int)x.z, x2);
 		x.w = __shfl((int)x.w, x1);
+#else
+		x.y = __shfl_sync(0xFFFFFFFF, (int)x.y, x3);
+		x.z = __shfl_sync(0xFFFFFFFF, (int)x.z, x2);
+		x.w = __shfl_sync(0xFFFFFFFF, (int)x.w, x1);
+#endif
 	}
 
 	b += x;
@@ -454,9 +532,15 @@ void chacha_xor_core(uint4 &b, uint4 &bx, const int x1, const int x2, const int 
 		CHACHA_PRIMITIVE(x.x ,x.w, x.y,  8)
 		CHACHA_PRIMITIVE(x.z ,x.y, x.w,  7)
 
+#if CUDA_VERSION < 9000
 		x.y = __shfl((int)x.y, x1);
 		x.z = __shfl((int)x.z, x2);
 		x.w = __shfl((int)x.w, x3);
+#else
+		x.y = __shfl_sync(0xFFFFFFFF, (int)x.y, x1);
+		x.z = __shfl_sync(0xFFFFFFFF, (int)x.z, x2);
+		x.w = __shfl_sync(0xFFFFFFFF, (int)x.w, x3);
+#endif
 
 		// Diagonal Mixing phase of chacha
 		CHACHA_PRIMITIVE(x.x ,x.w, x.y, 16)
@@ -464,9 +548,15 @@ void chacha_xor_core(uint4 &b, uint4 &bx, const int x1, const int x2, const int 
 		CHACHA_PRIMITIVE(x.x ,x.w, x.y,  8)
 		CHACHA_PRIMITIVE(x.z ,x.y, x.w,  7)
 
+#if CUDA_VERSION < 9000
 		x.y = __shfl((int)x.y, x3);
 		x.z = __shfl((int)x.z, x2);
 		x.w = __shfl((int)x.w, x1);
+#else
+		x.y = __shfl_sync(0xFFFFFFFF, (int)x.y, x3);
+		x.z = __shfl_sync(0xFFFFFFFF, (int)x.z, x2);
+		x.w = __shfl_sync(0xFFFFFFFF, (int)x.w, x1);
+#endif
 	}
 
 #undef CHACHA_PRIMITIVE
@@ -589,7 +679,11 @@ void titan_scrypt_core_kernelB(uint32_t *d_odata, int begin, int end)
 	} else load_key<ALGO>(d_odata, b, bx);
 
 	for (int i = begin; i < end; i++) {
+#if CUDA_VERSION < 9000
 		int j = (__shfl((int)bx.x, (threadIdx.x & 0x1c)) & (c_N_1));
+#else
+		int j = (__shfl_sync(0xFFFFFFFF, (int)bx.x, (threadIdx.x & 0x1c)) & (c_N_1));
+#endif
 		uint4 t, tx; read_keys_direct<SCHEME>(t, tx, start+32*j);
 		b ^= t; bx ^= tx;
 		block_mixer<ALGO>(b, bx, x1, x2, x3);
@@ -623,7 +717,11 @@ void titan_scrypt_core_kernelB_LG(uint32_t *d_odata, int begin, int end, unsigne
 	{
 		// better divergent thread handling submitted by nVidia engineers, but
 		// supposedly this does not run with the ANDERSEN memory access scheme
-		int j = (__shfl((int)bx.x, (threadIdx.x & 0x1c)) & (c_N_1));
+#if CUDA_VERSION < 9000
+        int j = (__shfl((int)bx.x, (threadIdx.x & 0x1c)) & (c_N_1));
+#else
+        int j = (__shfl_sync(0xFFFFFFFF, (int)bx.x, (threadIdx.x & 0x1c)) & (c_N_1));
+#endif
 		int pos = j/LOOKUP_GAP;
 		int loop = -1;
 		uint4 t, tx;
@@ -632,7 +730,11 @@ void titan_scrypt_core_kernelB_LG(uint32_t *d_odata, int begin, int end, unsigne
 		while(i < end)
 		{
 			if (loop == -1) {
-				j = (__shfl((int)bx.x, (threadIdx.x & 0x1c)) & (c_N_1));
+#if CUDA_VERSION < 9000
+                j = (__shfl((int)bx.x, (threadIdx.x & 0x1c)) & (c_N_1));
+#else
+                j = (__shfl_sync(0xFFFFFFFF, (int)bx.x, (threadIdx.x & 0x1c)) & (c_N_1));
+#endif
 				pos = j/LOOKUP_GAP;
 				loop = j-pos*LOOKUP_GAP;
 				read_keys_direct<SCHEME>(t, tx, start+32*pos);
@@ -655,7 +757,11 @@ void titan_scrypt_core_kernelB_LG(uint32_t *d_odata, int begin, int end, unsigne
 		// this is my original implementation, now used with the ANDERSEN
 		// memory access scheme only.
 		for (int i = begin; i < end; i++) {
-			int j = (__shfl((int)bx.x, (threadIdx.x & 0x1c)) & (c_N_1));
+#if CUDA_VERSION < 9000
+            int j = (__shfl((int)bx.x, (threadIdx.x & 0x1c)) & (c_N_1));
+#else
+            int j = (__shfl_sync(0xFFFFFFFF, (int)bx.x, (threadIdx.x & 0x1c)) & (c_N_1));
+#endif
 			int pos = j/LOOKUP_GAP, loop = j-pos*LOOKUP_GAP;
 			uint4 t, tx; read_keys_direct<SCHEME>(t, tx, start+32*pos);
 			while (loop--)

--- a/x11/cuda_x11_simd512.cu
+++ b/x11/cuda_x11_simd512.cu
@@ -196,6 +196,11 @@ do { \
 #endif
 #endif
 
+#if CUDA_VERSION >= 9000
+#undef __shfl
+#define __shfl(a, b, c) __shfl_sync(0xFFFFFFFF, a, b, c)
+#endif 
+
 /**
  * FFT_16 using w=2 as 16th root of unity
  * Unrolled decimation in frequency (DIF) radix-2 NTT.


### PR DESCRIPTION
Gets rid of warnings when compiling against cuda 9+ about __shfl, __any, and __shfl_up being deprecated