### PR TITLE
lyla2: Translate Japanese comments into English

### DIFF
--- a/lyra2/cuda_lyra2.cu
+++ b/lyra2/cuda_lyra2.cu
@@ -555,10 +555,10 @@ void lyra2_cpu_hash_32(int thr_id, uint32_t threads, uint32_t startNounce, uint6
 		size_t shared_mem = 0;
 
 		if (gtx750ti)
-			// 8Warpに調整のため、8192バイト確保する
+			// suitable amount to adjust for 8warp
 			shared_mem = 8192;
 		else
-			// 10Warpに調整のため、6144バイト確保する
+			// suitable amount to adjust for 10warp
 			shared_mem = 6144;
 
 		lyra2_gpu_hash_32_1_sm5 <<< grid2, block2 >>> (threads, startNounce, (uint2*)d_hash);

--- a/lyra2/cuda_lyra2.cu
+++ b/lyra2/cuda_lyra2.cu
@@ -555,8 +555,10 @@ void lyra2_cpu_hash_32(int thr_id, uint32_t threads, uint32_t startNounce, uint6
 		size_t shared_mem = 0;
 
 		if (gtx750ti)
+			// 8Warpに調整のため、8192バイト確保する
 			shared_mem = 8192;
 		else
+			// 10Warpに調整のため、6144バイト確保する
 			shared_mem = 6144;
 
 		lyra2_gpu_hash_32_1_sm5 <<< grid2, block2 >>> (threads, startNounce, (uint2*)d_hash);

--- a/lyra2/cuda_lyra2.cu
+++ b/lyra2/cuda_lyra2.cu
@@ -274,7 +274,7 @@ void reduceDuplexRowSetup(const int rowIn, const int rowInOut, const int rowOut,
 
 		ST4S(rowOut, Ncol - i - 1, state1, thread, threads);
 
-		//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+		// simultaneously receive data from preceding thread and send data to following thread
 		uint2 Data0 = state[0];
 		uint2 Data1 = state[1];
 		uint2 Data2 = state[2];
@@ -311,7 +311,7 @@ void reduceDuplexRowt(const int rowIn, const int rowInOut, const int rowOut, uin
 
 		round_lyra(state);
 
-		//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+		// simultaneously receive data from preceding thread and send data to following thread
 		uint2 Data0 = state[0];
 		uint2 Data1 = state[1];
 		uint2 Data2 = state[2];
@@ -356,7 +356,7 @@ void reduceDuplexRowt_8(const int rowInOut, uint2* state, const uint32_t thread,
 
 	round_lyra(state);
 
-	//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+	// simultaneously receive data from preceding thread and send data to following thread
 	uint2 Data0 = state[0];
 	uint2 Data1 = state[1];
 	uint2 Data2 = state[2];

--- a/lyra2/cuda_lyra2Z.cu
+++ b/lyra2/cuda_lyra2Z.cu
@@ -950,8 +950,10 @@ uint32_t lyra2Z_cpu_hash_32(int thr_id, uint32_t threads, uint32_t startNounce, 
 		size_t shared_mem = 0;
 
 		if (gtx750ti)
+			// 8Warpに調整のため、8192バイト確保する
 			shared_mem = 8192;
 		else
+			// 10Warpに調整のため、6144バイト確保する
 			shared_mem = 6144;
 
 		lyra2Z_gpu_hash_32_1_sm5 <<< grid2, block2 >>> (threads, startNounce, (uint2*)d_hash);

--- a/lyra2/cuda_lyra2Z.cu
+++ b/lyra2/cuda_lyra2Z.cu
@@ -510,7 +510,7 @@ void reduceDuplexRowSetup(const int rowIn, const int rowInOut, const int rowOut,
 
 		ST4S(rowOut, Ncol - i - 1, state1, thread, threads);
 
-		//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+		// simultaneously receive data from preceding thread and send data to following thread
 		uint2 Data0 = state[0];
 		uint2 Data1 = state[1];
 		uint2 Data2 = state[2];
@@ -547,7 +547,7 @@ void reduceDuplexRowt(const int rowIn, const int rowInOut, const int rowOut, uin
 
 		round_lyra(state);
 
-		//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+		// simultaneously receive data from preceding thread and send data to following thread
 		uint2 Data0 = state[0];
 		uint2 Data1 = state[1];
 		uint2 Data2 = state[2];
@@ -593,7 +593,7 @@ void reduceDuplexRowt_8(const int rowInOut, uint2* state, const uint32_t thread,
 
 	round_lyra(state);
 
-	//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+	// simultaneously receive data from preceding thread and send data to following thread
 	uint2 Data0 = state[0];
 	uint2 Data1 = state[1];
 	uint2 Data2 = state[2];
@@ -649,7 +649,7 @@ void reduceDuplexRowt_8_v2(const int rowIn, const int rowOut, const int rowInOut
 
 	round_lyra(state);
 
-	//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+	// simultaneously receive data from preceding thread and send data to following thread
 	uint2 Data0 = state[0];
 	uint2 Data1 = state[1];
 	uint2 Data2 = state[2];
@@ -950,10 +950,10 @@ uint32_t lyra2Z_cpu_hash_32(int thr_id, uint32_t threads, uint32_t startNounce, 
 		size_t shared_mem = 0;
 
 		if (gtx750ti)
-			// 8Warpに調整のため、8192バイト確保する
+			// suitable amount to adjust for 8warp
 			shared_mem = 8192;
 		else
-			// 10Warpに調整のため、6144バイト確保する
+			// suitable amount to adjust for 10warp
 			shared_mem = 6144;
 
 		lyra2Z_gpu_hash_32_1_sm5 <<< grid2, block2 >>> (threads, startNounce, (uint2*)d_hash);

--- a/lyra2/cuda_lyra2Z_sm5.cuh
+++ b/lyra2/cuda_lyra2Z_sm5.cuh
@@ -225,7 +225,7 @@ void reduceDuplexV5(uint2 state[4], const uint32_t thread, const uint32_t thread
 		for (int j = 0; j < 3; j++)
 			*(DMatrix + s2 + j*threads*blockDim.x) = state1[j] ^ state[j];
 
-		//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+		// simultaneously receive data from preceding thread and send data to following thread
 		uint2 Data0 = state[0];
 		uint2 Data1 = state[1];
 		uint2 Data2 = state[2];
@@ -271,7 +271,7 @@ void reduceDuplexV5(uint2 state[4], const uint32_t thread, const uint32_t thread
 		for (int j = 0; j < 3; j++)
 			*(DMatrix + s3 + j*threads*blockDim.x) = state1[j] ^ state[j];
 
-		//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+		// simultaneously receive data from preceding thread and send data to following thread
 		uint2 Data0 = state[0];
 		uint2 Data1 = state[1];
 		uint2 Data2 = state[2];
@@ -316,7 +316,7 @@ void reduceDuplexV5(uint2 state[4], const uint32_t thread, const uint32_t thread
 		for (int j = 0; j < 3; j++)
 			*(DMatrix + s4 + j*threads*blockDim.x) = state1[j] ^ state[j];
 
-		//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+		// simultaneously receive data from preceding thread and send data to following thread
 		uint2 Data0 = state[0];
 		uint2 Data1 = state[1];
 		uint2 Data2 = state[2];
@@ -360,7 +360,7 @@ void reduceDuplexV5(uint2 state[4], const uint32_t thread, const uint32_t thread
 		for (int j = 0; j < 3; j++)
 			*(DMatrix + s5 + j*threads*blockDim.x) = state1[j] ^ state[j];
 
-		//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+		// simultaneously receive data from preceding thread and send data to following thread
 		uint2 Data0 = state[0];
 		uint2 Data1 = state[1];
 		uint2 Data2 = state[2];
@@ -406,7 +406,7 @@ void reduceDuplexV5(uint2 state[4], const uint32_t thread, const uint32_t thread
 		for (int j = 0; j < 3; j++)
 			*(DMatrix + s6 + j*threads*blockDim.x) = state1[j] ^ state[j];
 
-		//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+		// simultaneously receive data from preceding thread and send data to following thread
 		uint2 Data0 = state[0];
 		uint2 Data1 = state[1];
 		uint2 Data2 = state[2];
@@ -452,7 +452,7 @@ void reduceDuplexV5(uint2 state[4], const uint32_t thread, const uint32_t thread
 		for (int j = 0; j < 3; j++)
 			*(DMatrix + s7 + j*threads*blockDim.x) = state1[j] ^ state[j];
 
-		//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+		// simultaneously receive data from preceding thread and send data to following thread
 		uint2 Data0 = state[0];
 		uint2 Data1 = state[1];
 		uint2 Data2 = state[2];
@@ -505,7 +505,7 @@ void reduceDuplexRowV50(const int rowIn, const int rowInOut, const int rowOut, u
 
 		round_lyra(state);
 
-		//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+		// simultaneously receive data from preceding thread and send data to following thread
 		uint2 Data0 = state[0];
 		uint2 Data1 = state[1];
 		uint2 Data2 = state[2];
@@ -554,7 +554,7 @@ void reduceDuplexRowV50_8(const int rowInOut, uint2 state[4], const uint32_t thr
 
 	round_lyra(state);
 
-	//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+	// simultaneously receive data from preceding thread and send data to following thread
 	uint2 Data0 = state[0];
 	uint2 Data1 = state[1];
 	uint2 Data2 = state[2];
@@ -618,7 +618,7 @@ void reduceDuplexRowV50_8_v2(const int rowIn, const int rowOut,const int rowInOu
 
 	round_lyra(state);
 
-	//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+	// simultaneously receive data from preceding thread and send data to following thread
 	uint2 Data0 = state[0];
 	uint2 Data1 = state[1];
 	uint2 Data2 = state[2];

--- a/lyra2/cuda_lyra2_sm5.cuh
+++ b/lyra2/cuda_lyra2_sm5.cuh
@@ -216,7 +216,7 @@ void reduceDuplexV5(uint2 state[4], const uint32_t thread, const uint32_t thread
 		for (int j = 0; j < 3; j++)
 			*(DMatrix + s2 + j*threads*blockDim.x) = state1[j] ^ state[j];
 
-		//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+		// simultaneously receive data from preceding thread and send data to following thread
 		uint2 Data0 = state[0];
 		uint2 Data1 = state[1];
 		uint2 Data2 = state[2];
@@ -262,7 +262,7 @@ void reduceDuplexV5(uint2 state[4], const uint32_t thread, const uint32_t thread
 		for (int j = 0; j < 3; j++)
 			*(DMatrix + s3 + j*threads*blockDim.x) = state1[j] ^ state[j];
 
-		//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+		// simultaneously receive data from preceding thread and send data to following thread
 		uint2 Data0 = state[0];
 		uint2 Data1 = state[1];
 		uint2 Data2 = state[2];
@@ -307,7 +307,7 @@ void reduceDuplexV5(uint2 state[4], const uint32_t thread, const uint32_t thread
 		for (int j = 0; j < 3; j++)
 			*(DMatrix + s4 + j*threads*blockDim.x) = state1[j] ^ state[j];
 
-		//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+		// simultaneously receive data from preceding thread and send data to following thread
 		uint2 Data0 = state[0];
 		uint2 Data1 = state[1];
 		uint2 Data2 = state[2];
@@ -351,7 +351,7 @@ void reduceDuplexV5(uint2 state[4], const uint32_t thread, const uint32_t thread
 		for (int j = 0; j < 3; j++)
 			*(DMatrix + s5 + j*threads*blockDim.x) = state1[j] ^ state[j];
 
-		//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+		// simultaneously receive data from preceding thread and send data to following thread
 		uint2 Data0 = state[0];
 		uint2 Data1 = state[1];
 		uint2 Data2 = state[2];
@@ -397,7 +397,7 @@ void reduceDuplexV5(uint2 state[4], const uint32_t thread, const uint32_t thread
 		for (int j = 0; j < 3; j++)
 			*(DMatrix + s6 + j*threads*blockDim.x) = state1[j] ^ state[j];
 
-		//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+		// simultaneously receive data from preceding thread and send data to following thread
 		uint2 Data0 = state[0];
 		uint2 Data1 = state[1];
 		uint2 Data2 = state[2];
@@ -443,7 +443,7 @@ void reduceDuplexV5(uint2 state[4], const uint32_t thread, const uint32_t thread
 		for (int j = 0; j < 3; j++)
 			*(DMatrix + s7 + j*threads*blockDim.x) = state1[j] ^ state[j];
 
-		//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+		// simultaneously receive data from preceding thread and send data to following thread
 		uint2 Data0 = state[0];
 		uint2 Data1 = state[1];
 		uint2 Data2 = state[2];
@@ -496,7 +496,7 @@ void reduceDuplexRowV50(const int rowIn, const int rowInOut, const int rowOut, u
 
 		round_lyra(state);
 
-		//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+		// simultaneously receive data from preceding thread and send data to following thread
 		uint2 Data0 = state[0];
 		uint2 Data1 = state[1];
 		uint2 Data2 = state[2];
@@ -545,7 +545,7 @@ void reduceDuplexRowV50_8(const int rowInOut, uint2 state[4], const uint32_t thr
 
 	round_lyra(state);
 
-	//一個手前のスレッドからデータを貰う(同時に一個先のスレッドにデータを送る)
+	// simultaneously receive data from preceding thread and send data to following thread
 	uint2 Data0 = state[0];
 	uint2 Data1 = state[1];
 	uint2 Data2 = state[2];


### PR DESCRIPTION
I believe that original rationale for this memory allocation for "Warp"-related adjustment is described here (<https://askmona.org/4314#res_666>).

> GTX950は6SM構成のため(768[コア]÷128[コア/SM]＝6[SM])、1WarpあたりのL2キャッシュ占有量は 1.5[kB/スレッド]×6[SM]×32[スレッド/SM･Warp]＝288[kB/Warp] となる。
> GTX950のL2キャッシュは1MBのため、1024[kB]÷288[kB/Warp]＝3.55[Warp]となり、3Warpが最適となる。
> 3Warpではコアをすべて使用することができないため、シェアードメモリとの併用を考える。
> シェアードメモリで「8分の1」だけ利用する場合、L2キャッシュからみたWarp数は1024[kB]÷(288[kB/Warp]×7/8)＝4.06[Warp]となり、4Warp確保できる。
> このとき、シェアードメモリの使用量は、(1.5[kB/スレッド]×1/8)×32[スレッド/SM･Warp]×4[Warp]＝24[kB/SM]となり、シェアードメモリは十分確保できる。
> よって、「シェアードメモリとL2キャッシュの混在」によりCUDAコアを十分活用できることがわかる。
> 現状、GTX950以上はシェアードメモリのみを使用し、2Warp構成で動作するため、CUDAコアをすべて使用できていないため、「シェアードメモリとL2キャッシュの混在」の手法で高速化する可能性がある。(L2のレイテンシと分岐ダイバージェンスの影響があるため、やってみないと何とも言えないが…)

Summarized:

- Considering the 1MB L2 cache (and 6SM amount for GTX950), 3Warp is going to be suitable
- However, 3Warp is not enough to consume all CUDA cores
- For above reason, introduce shared memory usage
- CUDA cores are fully utilized thanks to mixing shared memory & L2 cache

Related to: #38 