### PR TITLE
add hsr to help output

### DIFF
--- a/ccminer.cpp
+++ b/ccminer.cpp
@@ -256,6 +256,7 @@ Options:\n\
 "			heavy       Heavycoin\n"
 #endif
 "			hmq1725     Doubloons / Espers\n\
+			hsr         HSR (Hshare/Hcash)\n\
 			jackpot     JHA v8\n\
 			keccak      Deprecated Keccak-256\n\
 			keccakc     Keccak-256 (CreativeCoin)\n\


### PR DESCRIPTION
I went digging around for a miner to handle the HSR algorithm, not knowing that it'd already been here for the past three releases because it didn't show up when I punched in ccminer --help.  This pull request fixes that.