### PR TITLE
Update instructions for Fedora 27

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -29,7 +29,7 @@ Then use the helper ./build.sh in ccminer source folder, edit configure.sh and t
 ```
 
 
-** How to compile on Fedora 25 **
+** How to compile on Fedora 27 **
 
 Note: You may find an alternative method via rpms :
 see https://negativo17.org/nvidia-driver/ and https://negativo17.org/repos/multimedia/
@@ -66,7 +66,7 @@ ldconfig
 # see https://gcc.gnu.org/mirrors.html
 # Note: this manual method will override the default gcc, it could be better to use a custom toolchain prefix
 
-wget ftp://ftp.lip6.fr/pub/gcc/releases/gcc-5.4.0/gcc-5.4.0.tar.bz2
+wget ftp://ftp.lip6.fr/pub/gcc/releases/gcc-5.5.0/gcc-5.5.0.tar.xz
 dnf install libmpc-devel mpfr-devel gmp-devel
 ./configure --prefix=/usr/local --enable-languages=c,c++,lto --disable-multilib
 make -j 8 && make install


### PR DESCRIPTION
GCC 5.4.0 does not seem to compile on Fedora 27, so I needed to use 5.5.0. An additional step I needed was to append the line `#define _BITS_FLOATN_H` to /usr/local/cuda-8.0/include/host_defines.h as mentioned in this comment: https://github.com/tensorflow/tensorflow/issues/16165#issuecomment-359191728 (this seems to be needed due to glibc 2.26) -- not sure the best way to mention this in the instructions.