### PR TITLE
experimental lapo changes (don't pull, pls comment)

### DIFF
--- a/ccminer.cpp
+++ b/ccminer.cpp
@@ -1643,6 +1643,15 @@ static bool stratum_gen_work(struct stratum_ctx *sctx, struct work *work)
 		memcpy(&work->data[12], sctx->job.coinbase, 32); // merkle_root
 		work->data[20] = 0x80000000;
 		if (opt_debug) applog_hex(work->data, 80);
+	} else if (opt_algo == ALGO_LYRA2ZZ){
+		for (i = 0; i < 8; i++)
+			work->data[9 + i] = be32dec((uint32_t *)merkle_root + i);
+		work->data[17] = le32dec(sctx->job.ntime);
+		work->data[18] = le32dec(sctx->job.nbits);
+		for (i = 0; i < 8; i++)
+			work->data[20 + i] = be32dec((uint32_t *)sctx->job.accmulatorcheckpoint + i);
+		work->data[28] = 0x80000000;
+		work->data[31] = (opt_algo == ALGO_MJOLLNIR) ? 0x000002A0 : 0x00000280;
 	} else {
 		for (i = 0; i < 8; i++)
 			work->data[9 + i] = be32dec((uint32_t *)merkle_root + i);
@@ -1706,6 +1715,7 @@ static bool stratum_gen_work(struct stratum_ctx *sctx, struct work *work)
 		case ALGO_LBRY:
 		case ALGO_LYRA2v2:
 		case ALGO_LYRA2Z:
+		case ALGO_LYRA2ZZ:
 		case ALGO_TIMETRAVEL:
 		case ALGO_BITCORE:
 		case ALGO_X16R:
@@ -2261,6 +2271,7 @@ static void *miner_thread(void *userdata)
 				break;
 			case ALGO_LYRA2:
 			case ALGO_LYRA2Z:
+			case ALGO_LYRA2ZZ:
 			case ALGO_NEOSCRYPT:
 			case ALGO_SIB:
 			case ALGO_SCRYPT:
@@ -2417,6 +2428,9 @@ static void *miner_thread(void *userdata)
 			break;
 		case ALGO_LYRA2Z:
 			rc = scanhash_lyra2Z(thr_id, &work, max_nonce, &hashes_done);
+			break;
+		case ALGO_LYRA2ZZ:
+			rc = scanhash_lyra2Zz(thr_id, &work, max_nonce, &hashes_done);
 			break;
 		case ALGO_NEOSCRYPT:
 			rc = scanhash_neoscrypt(thr_id, &work, max_nonce, &hashes_done);

--- a/lyra2/lyra2Z.cu
+++ b/lyra2/lyra2Z.cu
@@ -36,6 +36,21 @@ extern "C" void lyra2Z_hash(void *state, const void *input)
 	memcpy(state, hashB, 32);
 }
 
+extern "C" void lyra2Z_hash_112(void *state, const void *input)
+{
+	uint32_t _ALIGN(64) hashA[8], hashB[8];
+	sph_blake256_context ctx_blake;
+
+	sph_blake256_set_rounds(14);
+	sph_blake256_init(&ctx_blake);
+	sph_blake256(&ctx_blake, input, 112);
+	sph_blake256_close(&ctx_blake, hashA);
+
+	LYRA2Z(hashB, 32, hashA, 32, hashA, 32, 8, 8, 8);
+
+	memcpy(state, hashB, 32);
+}
+
 static bool init[MAX_GPUS] = { 0 };
 static __thread uint32_t throughput = 0;
 static __thread bool gtx750ti = false;
@@ -98,6 +113,114 @@ extern "C" int scanhash_lyra2Z(int thr_id, struct work* work, uint32_t max_nonce
 		int order = 0;
 
 		blake256_cpu_hash_80(thr_id, throughput, pdata[19], d_hash[thr_id], order++);
+
+		*hashes_done = pdata[19] - first_nonce + throughput;
+
+		work->nonces[0] = lyra2Z_cpu_hash_32(thr_id, throughput, pdata[19], d_hash[thr_id], gtx750ti);
+
+		if (work->nonces[0] != UINT32_MAX)
+		{
+			uint32_t _ALIGN(64) vhash[8];
+
+			be32enc(&endiandata[19], work->nonces[0]);
+			lyra2Z_hash(vhash, endiandata);
+
+			if (vhash[7] <= ptarget[7] && fulltest(vhash, ptarget)) {
+				work->valid_nonces = 1;
+				work->nonces[1] = lyra2Z_getSecNonce(thr_id, 1);
+				work_set_target_ratio(work, vhash);
+				pdata[19] = work->nonces[0] + 1;
+				if (work->nonces[1] != UINT32_MAX)
+				{
+					be32enc(&endiandata[19], work->nonces[1]);
+					lyra2Z_hash(vhash, endiandata);
+					if (vhash[7] <= ptarget[7] && fulltest(vhash, ptarget)) {
+						bn_set_target_ratio(work, vhash, 1);
+						work->valid_nonces++;
+					}
+					pdata[19] = max(work->nonces[0], work->nonces[1]) + 1; // cursor
+				}
+				return work->valid_nonces;
+			}
+			else if (vhash[7] > ptarget[7]) {
+				gpu_increment_reject(thr_id);
+				if (!opt_quiet)	gpulog(LOG_WARNING, thr_id,
+					"result for %08x does not validate on CPU!", work->nonces[0]);
+				pdata[19] = work->nonces[0];
+				continue;
+			}
+		}
+
+		if ((uint64_t)throughput + pdata[19] >= max_nonce) {
+			pdata[19] = max_nonce;
+			break;
+		}
+		pdata[19] += throughput;
+
+	} while (!work_restart[thr_id].restart);
+
+	*hashes_done = pdata[19] - first_nonce;
+	return 0;
+}
+
+extern "C" int scanhash_lyra2Zz(int thr_id, struct work* work, uint32_t max_nonce, unsigned long *hashes_done)
+{
+	uint32_t *pdata = work->data;
+	uint32_t *ptarget = work->target;
+	uint32_t _ALIGN(64) endiandata[20];
+	const uint32_t first_nonce = pdata[19];
+	int dev_id = device_map[thr_id];
+
+	if (opt_benchmark)
+		ptarget[7] = 0x00ff;
+
+	if (!init[thr_id])
+	{
+		cudaSetDevice(dev_id);
+		if (opt_cudaschedule == -1 && gpu_threads == 1) {
+			cudaDeviceReset();
+			cudaSetDeviceFlags(cudaDeviceScheduleBlockingSync);
+			CUDA_LOG_ERROR();
+		}
+
+		cuda_get_arch(thr_id);
+		int intensity = (device_sm[dev_id] > 500 && !is_windows()) ? 17 : 16;
+		if (device_sm[dev_id] <= 500) intensity = 15;
+		throughput = cuda_default_throughput(thr_id, 1U << intensity); // 18=256*256*4;
+		if (init[thr_id]) throughput = min(throughput, max_nonce - first_nonce);
+
+		cudaDeviceProp props;
+		cudaGetDeviceProperties(&props, dev_id);
+		gtx750ti = (strstr(props.name, "750 Ti") != NULL);
+
+		gpulog(LOG_INFO, thr_id, "Intensity set to %g, %u cuda threads", throughput2intensity(throughput), throughput);
+
+		blake256_cpu_init(thr_id, throughput);
+
+		if (device_sm[dev_id] >= 350)
+		{
+			size_t matrix_sz = device_sm[dev_id] > 500 ? sizeof(uint64_t) * 4 * 4 : sizeof(uint64_t) * 8 * 8 * 3 * 4;
+			CUDA_SAFE_CALL(cudaMalloc(&d_matrix[thr_id], matrix_sz * throughput));
+			lyra2Z_cpu_init(thr_id, throughput, d_matrix[thr_id]);
+		}
+		else
+			lyra2Z_cpu_init_sm2(thr_id, throughput);
+
+		CUDA_SAFE_CALL(cudaMalloc(&d_hash[thr_id], (size_t)32 * throughput));
+
+		init[thr_id] = true;
+	}
+
+	for (int k=0; k < 28; k++)
+		be32enc(&endiandata[k], pdata[k]);
+
+	blake256_cpu_setBlock_112(pdata);
+	lyra2Z_setTarget(ptarget);
+
+	do {
+		int order = 0;
+
+		blake256_cpu_hash_112(thr_id, throughput, pdata[19], d_hash[thr_id], order++);
 
 		*hashes_done = pdata[19] - first_nonce + throughput;
 

--- a/miner.h
+++ b/miner.h
@@ -662,6 +662,7 @@ struct stratum_job {
 	unsigned char *xnonce2;
 	int merkle_count;
 	unsigned char **merkle;
+	unsigned char accumulatorcheckpoint[32];
 	unsigned char version[4];
 	unsigned char nbits[4];
 	unsigned char ntime[4];


### PR DESCRIPTION
Tanguy, I am trying to modify ccminer to work with a new coin. The hash algorithm is Lyra2z, but the block size is 112 bytes instead of 80 bytes because it has an accumulator checkpoint for Zerocoin. It looks like so:
```
    static const int32_t CURRENT_VERSION=4;
    int32_t nVersion;
    uint256 hashPrevBlock;
    uint256 hashMerkleRoot;
    uint32_t nTime;
    uint32_t nBits;
    uint32_t nNonce;
    uint256 nAccumulatorCheckpoint;
```
and I can deliver the following via gbt
```
{
  "capabilities": [
    "proposal"
  ],
  "version": 4,
  "previousblockhash": "00000031a4ee3ecada198fab13f43e616204df8f8f5670cddb975de9a56490f4",
  "transactions": [
  ],
  "coinbaseaux": {
    "flags": ""
  },
  "coinbasevalue": 2250000000,
  "longpollid": "00000031a4ee3ecada198fab13f43e616204df8f8f5670cddb975de9a56490f4332",
  "target": "0000053d5e000000000000000000000000000000000000000000000000000000",
  "mintime": 1523402951,
  "mutable": [
    "time",
    "transactions",
    "prevblock"
  ],
  "noncerange": "00000000ffffffff",
  "curtime": 1523403173,
  "bits": "1e053d5e",
  "height": 481,
  "accumulatorcheckpoint": "405685d1c6935cd447a384bd535197ba93b453c268aa36af66b6b47a6e25e95b",
  "votes": [
  ],
  "payee": "",
  "payee_amount": "",
  "masternode_payments": true,
  "enforce_masternode_payments": true
}
```
Code is duplicative for now (didn't want to step on the current implementation) but I'm super sketchy on the padding. I guessed I should change it to
```
__device__ __constant__ static const uint32_t  c_Padding_112[16] = {
	0, 0, 0, 0,
	0, 0, 0, 0,
	0x80000000, 0, 0, 0,
	0, 1, 0, 640,
};
```
since I use up another 32 bytes, but I'm not sure what the 1 and the 640 refer to at the end. Any tips or assistance would be much appreciated.

Oh, also, I'm not sure how I can extract 'accumulatorcheckpoint' from the getblocktemplate output. Is it it in utils.cpp?

**Update** Seems that my getblocktemplate params are all out of order too...