### PR TITLE
Replace cudaThreadSynchronize with cudaDeviceSynchronize

### DIFF
--- a/Algo256/bmw.cu
+++ b/Algo256/bmw.cu
@@ -127,7 +127,7 @@ extern "C" void free_bmw(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 	bmw256_midstate_free(thr_id);

--- a/Algo256/cuda_keccak256.cu
+++ b/Algo256/cuda_keccak256.cu
@@ -207,7 +207,7 @@ void keccak256_cpu_hash_80(int thr_id, uint32_t threads, uint32_t startNonce, ui
 	const dim3 block(tpb);
 
 	keccak256_gpu_hash_80<<<grid, block>>>(threads, startNonce, d_nonces[thr_id], highTarget);
-//	cudaThreadSynchronize();
+//	cudaDeviceSynchronize();
 	cudaMemcpy(h_nonces[thr_id], d_nonces[thr_id], NBN*sizeof(uint32_t), cudaMemcpyDeviceToHost);
 	memcpy(resNonces, h_nonces[thr_id], NBN*sizeof(uint32_t));
 }

--- a/Algo256/cuda_keccak256_sm3.cu
+++ b/Algo256/cuda_keccak256_sm3.cu
@@ -222,7 +222,7 @@ void keccak256_sm3_hash_80(int thr_id, uint32_t threads, uint32_t startNounce, u
 	keccak256_sm3_gpu_hash_80<<<grid, block, shared_size>>>(threads, startNounce, d_KNonce[thr_id]);
 
 	cudaMemcpy(resNonces, d_KNonce[thr_id], 2*sizeof(uint32_t), cudaMemcpyDeviceToHost);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 }
 
 #if 0

--- a/Algo256/keccak256.cu
+++ b/Algo256/keccak256.cu
@@ -162,7 +162,7 @@ extern "C" void free_keccak256(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	if(!use_compat_kernels[thr_id])
 		keccak256_cpu_free(thr_id);

--- a/Algo256/vanilla.cu
+++ b/Algo256/vanilla.cu
@@ -481,7 +481,7 @@ extern "C" void free_vanilla(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFreeHost(h_resNonce[thr_id]);
 	cudaFree(d_resNonce[thr_id]);

--- a/JHA/jackpotcoin.cu
+++ b/JHA/jackpotcoin.cu
@@ -273,7 +273,7 @@ extern "C" void free_jackpot(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_branch1Nonces[thr_id]);
 	cudaFree(d_branch2Nonces[thr_id]);

--- a/JHA/jha.cu
+++ b/JHA/jha.cu
@@ -248,7 +248,7 @@ extern "C" void free_jha(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 	cudaFree(d_hash_br2[thr_id]);

--- a/blake2b.cu
+++ b/blake2b.cu
@@ -142,7 +142,7 @@ uint32_t blake2b_hash_cuda(const int thr_id, const uint32_t threads, const uint3
 		return result;
 
 	blake2b_gpu_hash <<<grid, block, 8>>> (threads, startNonce, d_resNonces[thr_id], target2);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	if (cudaSuccess == cudaMemcpy(resNonces, d_resNonces[thr_id], NBN*sizeof(uint32_t), cudaMemcpyDeviceToHost)) {
 		result = resNonces[0];
@@ -263,7 +263,7 @@ extern "C" void free_blake2b(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	//cudaThreadSynchronize();
+	//cudaDeviceSynchronize();
 
 	cudaFree(d_resNonces[thr_id]);
 

--- a/crypto/wildkeccak.cu
+++ b/crypto/wildkeccak.cu
@@ -366,7 +366,7 @@ void free_wildkeccak(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_scratchpad[thr_id]);
 	cudaFree(d_input[thr_id]);

--- a/cuda_checkhash.cu
+++ b/cuda_checkhash.cu
@@ -134,7 +134,7 @@ uint32_t cuda_check_hash(int thr_id, uint32_t threads, uint32_t startNounce, uin
 	}
 
 	cuda_checkhash_64 <<<grid, block>>> (threads, startNounce, d_inputHash, d_resNonces[thr_id]);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaMemcpy(h_resNonces[thr_id], d_resNonces[thr_id], sizeof(uint32_t), cudaMemcpyDeviceToHost);
 	return h_resNonces[thr_id][0];
@@ -159,7 +159,7 @@ uint32_t cuda_check_hash_32(int thr_id, uint32_t threads, uint32_t startNounce, 
 	}
 
 	cuda_checkhash_32 <<<grid, block>>> (threads, startNounce, d_inputHash, d_resNonces[thr_id]);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaMemcpy(h_resNonces[thr_id], d_resNonces[thr_id], sizeof(uint32_t), cudaMemcpyDeviceToHost);
 	return h_resNonces[thr_id][0];
@@ -200,7 +200,7 @@ uint32_t cuda_check_hash_suppl(int thr_id, uint32_t threads, uint32_t startNounc
 	cudaMemset(d_resNonces[thr_id], 0, sizeof(uint32_t));
 
 	cuda_checkhash_64_suppl <<<grid, block>>> (startNounce, d_inputHash, d_resNonces[thr_id]);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaMemcpy(h_resNonces[thr_id], d_resNonces[thr_id], 32, cudaMemcpyDeviceToHost);
 	rescnt = h_resNonces[thr_id][0];
@@ -266,7 +266,7 @@ uint32_t cuda_check_hash_branch(int thr_id, uint32_t threads, uint32_t startNoun
 
 	cudaMemcpy(h_resNonces[thr_id], d_resNonces[thr_id], sizeof(uint32_t), cudaMemcpyDeviceToHost);
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	result = *h_resNonces[thr_id];
 
 	return result;

--- a/fuguecoin.cpp
+++ b/fuguecoin.cpp
@@ -104,7 +104,7 @@ void free_fugue256(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	fugue256_cpu_free(thr_id);
 

--- a/groestlcoin.cpp
+++ b/groestlcoin.cpp
@@ -104,7 +104,7 @@ void free_groestlcoin(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	groestlcoin_cpu_free(thr_id);
 	init[thr_id] = false;

--- a/heavy/bastion.cu
+++ b/heavy/bastion.cu
@@ -212,7 +212,7 @@ extern "C" void free_bastion(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 	cudaFree(d_hash_br1[thr_id]);

--- a/heavy/cuda_keccak512.cu
+++ b/heavy/cuda_keccak512.cu
@@ -263,7 +263,7 @@ void keccak512_cpu_copyHeftyHash(int thr_id, uint32_t threads, void *heftyHashes
 	// Hefty1 Hashes kopieren
 	if (copy)
 		CUDA_SAFE_CALL(cudaMemcpy(heavy_heftyHashes[thr_id], heftyHashes, 8 * sizeof(uint32_t) * threads, cudaMemcpyHostToDevice));
-	//else cudaThreadSynchronize();
+	//else cudaDeviceSynchronize();
 }
 
 __host__

--- a/heavy/cuda_sha256.cu
+++ b/heavy/cuda_sha256.cu
@@ -260,7 +260,7 @@ __host__ void sha256_cpu_copyHeftyHash(int thr_id, uint32_t threads, void *hefty
 	// Hefty1 Hashes kopieren
 	if (copy)
 		CUDA_SAFE_CALL(cudaMemcpy(heavy_heftyHashes[thr_id], heftyHashes, 8 * sizeof(uint32_t) * threads, cudaMemcpyHostToDevice));
-	//else cudaThreadSynchronize();
+	//else cudaDeviceSynchronize();
 }
 
 __host__ void sha256_cpu_hash(int thr_id, uint32_t threads, int startNounce)

--- a/heavy/heavy.cu
+++ b/heavy/heavy.cu
@@ -316,7 +316,7 @@ extern "C" void free_heavy(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(heavy_nonceVector[thr_id]);
 

--- a/lbry/lbry.cu
+++ b/lbry/lbry.cu
@@ -229,7 +229,7 @@ void free_lbry(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	if(device_sm[device_map[thr_id]] <= 500)
 		cudaFree(d_hash[thr_id]);

--- a/lyra2/allium.cu
+++ b/lyra2/allium.cu
@@ -203,7 +203,7 @@ extern "C" void free_allium(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 	cudaFree(d_matrix[thr_id]);

--- a/lyra2/lyra2RE.cu
+++ b/lyra2/lyra2RE.cu
@@ -186,7 +186,7 @@ extern "C" void free_lyra2(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 	cudaFree(d_matrix[thr_id]);

--- a/lyra2/lyra2REv2.cu
+++ b/lyra2/lyra2REv2.cu
@@ -195,7 +195,7 @@ extern "C" void free_lyra2v2(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 	cudaFree(d_matrix[thr_id]);

--- a/lyra2/lyra2REv3.cu
+++ b/lyra2/lyra2REv3.cu
@@ -172,7 +172,7 @@ extern "C" void free_lyra2v3(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 	cudaFree(d_matrix[thr_id]);

--- a/lyra2/lyra2Z.cu
+++ b/lyra2/lyra2Z.cu
@@ -155,7 +155,7 @@ extern "C" void free_lyra2Z(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 	if (device_sm[dev_id] >= 350)

--- a/myriadgroestl.cpp
+++ b/myriadgroestl.cpp
@@ -121,7 +121,7 @@ void free_myriad(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	myriadgroestl_cpu_free(thr_id);
 	init[thr_id] = false;

--- a/neoscrypt/neoscrypt.cpp
+++ b/neoscrypt/neoscrypt.cpp
@@ -112,7 +112,7 @@ void free_neoscrypt(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	neoscrypt_free(thr_id);
 	init[thr_id] = false;

--- a/pentablake.cu
+++ b/pentablake.cu
@@ -149,7 +149,7 @@ void free_pentablake(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 

--- a/phi/phi.cu
+++ b/phi/phi.cu
@@ -211,7 +211,7 @@ extern "C" void free_phi(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	cudaFree(d_hash[thr_id]);
 	cudaFree(d_resNonce[thr_id]);
 	x13_fugue512_cpu_free(thr_id);

--- a/phi/phi2.cu
+++ b/phi/phi2.cu
@@ -254,7 +254,7 @@ extern "C" void free_phi2(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	cudaFree(d_matrix[thr_id]);
 	cudaFree(d_hash_512[thr_id]);
 	cudaFree(d_hash_256[thr_id]);

--- a/polytimos.cu
+++ b/polytimos.cu
@@ -203,7 +203,7 @@ extern "C" void free_polytimos(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 	x13_fugue512_cpu_free(thr_id);

--- a/quark/nist5.cu
+++ b/quark/nist5.cu
@@ -171,7 +171,7 @@ extern "C" void free_nist5(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 

--- a/quark/quarkcoin.cu
+++ b/quark/quarkcoin.cu
@@ -316,7 +316,7 @@ extern "C" void free_quark(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 

--- a/qubit/deep.cu
+++ b/qubit/deep.cu
@@ -146,7 +146,7 @@ extern "C" void free_deep(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 

--- a/qubit/luffa.cu
+++ b/qubit/luffa.cu
@@ -122,7 +122,7 @@ extern "C" void free_luffa(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 

--- a/qubit/qubit.cu
+++ b/qubit/qubit.cu
@@ -162,7 +162,7 @@ extern "C" void free_qubit(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 

--- a/sha256/cuda_sha256d.cu
+++ b/sha256/cuda_sha256d.cu
@@ -466,9 +466,9 @@ void sha256d_hash_80(int thr_id, uint32_t threads, uint32_t startNonce, uint32_t
 	dim3 block(threadsperblock);
 
 	CUDA_SAFE_CALL(cudaMemset(d_resNonces[thr_id], 0xFF, 2 * sizeof(uint32_t)));
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	sha256d_gpu_hash_shared <<<grid, block>>> (threads, startNonce, d_resNonces[thr_id]);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	CUDA_SAFE_CALL(cudaMemcpy(resNonces, d_resNonces[thr_id], 2 * sizeof(uint32_t), cudaMemcpyDeviceToHost));
 	if (resNonces[0] == resNonces[1]) {

--- a/sha256/cuda_sha256q.cu
+++ b/sha256/cuda_sha256q.cu
@@ -496,9 +496,9 @@ void sha256q_hash_80(int thr_id, uint32_t threads, uint32_t startNonce, uint32_t
 	dim3 block(threadsperblock);
 
 	CUDA_SAFE_CALL(cudaMemset(d_resNonces[thr_id], 0xFF, 2 * sizeof(uint32_t)));
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	sha256q_gpu_hash_shared <<<grid, block>>> (threads, startNonce, d_resNonces[thr_id]);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	CUDA_SAFE_CALL(cudaMemcpy(resNonces, d_resNonces[thr_id], 2 * sizeof(uint32_t), cudaMemcpyDeviceToHost));
 	if (resNonces[0] == resNonces[1]) {

--- a/sha256/cuda_sha256t.cu
+++ b/sha256/cuda_sha256t.cu
@@ -480,9 +480,9 @@ void sha256t_hash_80(int thr_id, uint32_t threads, uint32_t startNonce, uint32_t
 	dim3 block(threadsperblock);
 
 	CUDA_SAFE_CALL(cudaMemset(d_resNonces[thr_id], 0xFF, 2 * sizeof(uint32_t)));
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 	sha256t_gpu_hash_shared <<<grid, block>>> (threads, startNonce, d_resNonces[thr_id]);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	CUDA_SAFE_CALL(cudaMemcpy(resNonces, d_resNonces[thr_id], 2 * sizeof(uint32_t), cudaMemcpyDeviceToHost));
 	if (resNonces[0] == resNonces[1]) {

--- a/sha256/sha256d.cu
+++ b/sha256/sha256d.cu
@@ -117,7 +117,7 @@ extern "C" void free_sha256d(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	sha256d_free(thr_id);
 

--- a/sha256/sha256q.cu
+++ b/sha256/sha256q.cu
@@ -126,7 +126,7 @@ extern "C" void free_sha256q(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	sha256q_free(thr_id);
 

--- a/sha256/sha256t.cu
+++ b/sha256/sha256t.cu
@@ -121,7 +121,7 @@ extern "C" void free_sha256t(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	sha256t_free(thr_id);
 

--- a/sia/sia.cu
+++ b/sia/sia.cu
@@ -167,7 +167,7 @@ uint32_t sia_blake2b_hash_cuda(const int thr_id, const uint32_t threads, const u
 		return result;
 
 	sia_blake2b_gpu_hash <<<grid, block, 8>>> (threads, startNonce, d_resNonces[thr_id], target2);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	if (cudaSuccess == cudaMemcpy(resNonces, d_resNonces[thr_id], NBN*sizeof(uint32_t), cudaMemcpyDeviceToHost)) {
 		result = resNonces[0];
@@ -294,7 +294,7 @@ extern "C" void free_sia(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_resNonces[thr_id]);
 

--- a/skein.cu
+++ b/skein.cu
@@ -469,7 +469,7 @@ extern "C" void free_skeincoin(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	if (sm5)
 		skeincoin_free(thr_id);

--- a/skein2.cpp
+++ b/skein2.cpp
@@ -138,7 +138,7 @@ void free_skein2(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 

--- a/skunk/skunk.cu
+++ b/skunk/skunk.cu
@@ -197,7 +197,7 @@ extern "C" void free_skunk(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	if (use_compat_kernels[thr_id])
 		x13_fugue512_cpu_free(thr_id);

--- a/tribus/tribus.cu
+++ b/tribus/tribus.cu
@@ -172,7 +172,7 @@ extern "C" void free_tribus(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 	cudaFree(d_resNonce[thr_id]);

--- a/x11/bitcore.cu
+++ b/x11/bitcore.cu
@@ -424,7 +424,7 @@ extern "C" void free_bitcore(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 

--- a/x11/c11.cu
+++ b/x11/c11.cu
@@ -253,7 +253,7 @@ extern "C" void free_c11(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 	cudaFree(d_resNonce[thr_id]);

--- a/x11/exosis.cu
+++ b/x11/exosis.cu
@@ -483,7 +483,7 @@ extern "C" void free_exosis(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 

--- a/x11/fresh.cu
+++ b/x11/fresh.cu
@@ -120,7 +120,7 @@ extern "C" int scanhash_fresh(int thr_id, struct work* work, uint32_t max_nonce,
 #if NULLTEST
 		uint32_t buf[8]; memset(buf, 0, sizeof buf);
 		CUDA_SAFE_CALL(cudaMemcpy(buf, d_hash[thr_id], sizeof buf, cudaMemcpyDeviceToHost));
-		CUDA_SAFE_CALL(cudaThreadSynchronize());
+		CUDA_SAFE_CALL(cudaDeviceSynchronize());
 		print_hash((unsigned char*)buf); printf("\n");
 #endif
 		*hashes_done = pdata[19] - first_nonce + throughput;

--- a/x11/s3.cu
+++ b/x11/s3.cu
@@ -169,7 +169,7 @@ extern "C" void free_s3(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 	x11_simd512_cpu_free(thr_id);

--- a/x11/sib.cu
+++ b/x11/sib.cu
@@ -236,7 +236,7 @@ extern "C" void free_sib(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 

--- a/x11/timetravel.cu
+++ b/x11/timetravel.cu
@@ -483,7 +483,7 @@ extern "C" void free_timetravel(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 

--- a/x11/veltor.cu
+++ b/x11/veltor.cu
@@ -186,7 +186,7 @@ extern "C" void free_veltor(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 	cudaFree(d_resNonce[thr_id]);

--- a/x11/x11.cu
+++ b/x11/x11.cu
@@ -218,7 +218,7 @@ extern "C" void free_x11(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 

--- a/x11/x11evo.cu
+++ b/x11/x11evo.cu
@@ -399,7 +399,7 @@ extern "C" void free_x11evo(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 

--- a/x12/x12.cu
+++ b/x12/x12.cu
@@ -232,7 +232,7 @@ extern "C" void free_x12(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 

--- a/x13/hsr.cu
+++ b/x13/hsr.cu
@@ -248,7 +248,7 @@ extern "C" void free_hsr(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 

--- a/x13/x13.cu
+++ b/x13/x13.cu
@@ -237,7 +237,7 @@ extern "C" void free_x13(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 

--- a/x15/cuda_whirlpoolx.cu
+++ b/x15/cuda_whirlpoolx.cu
@@ -571,7 +571,7 @@ void whirlpoolx_precompute(int thr_id)
 	dim3 block(256);
 
 	whirlpoolx_gpu_precompute <<<grid, block>>>(8, d_xtra[thr_id], d_tmp[thr_id]);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaMemcpyToSymbol(c_xtra, d_xtra[thr_id], 8 * sizeof(uint64_t), 0, cudaMemcpyDeviceToDevice);
 	CUDA_SAFE_CALL(cudaMemcpyToSymbol(c_tmp, d_tmp[thr_id], 8 * 9 * sizeof(uint64_t), 0, cudaMemcpyDeviceToDevice));
@@ -586,7 +586,7 @@ uint32_t whirlpoolx_cpu_hash(int thr_id, uint32_t threads, uint32_t startNounce)
 	cudaMemset(d_WXNonce[thr_id], 0xff, sizeof(uint32_t));
 
 	whirlpoolx_gpu_hash<<<grid, block>>>(threads, startNounce, d_WXNonce[thr_id]);
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaMemcpy(h_wxnounce[thr_id], d_WXNonce[thr_id], sizeof(uint32_t), cudaMemcpyDeviceToHost);
 

--- a/x15/whirlpool.cu
+++ b/x15/whirlpool.cu
@@ -166,7 +166,7 @@ extern "C" void free_whirl(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 #ifdef SM3_VARIANT
 	cudaFree(d_hash[thr_id]);

--- a/x15/whirlpoolx.cu
+++ b/x15/whirlpoolx.cu
@@ -116,7 +116,7 @@ extern "C" void free_whirlx(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 

--- a/x15/x14.cu
+++ b/x15/x14.cu
@@ -253,7 +253,7 @@ extern "C" void free_x14(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	quark_blake512_cpu_free(thr_id);
 	quark_groestl512_cpu_free(thr_id);

--- a/x15/x15.cu
+++ b/x15/x15.cu
@@ -258,7 +258,7 @@ extern "C" void free_x15(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 

--- a/x16/x16r.cu
+++ b/x16/x16r.cu
@@ -605,7 +605,7 @@ extern "C" void free_x16r(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 

--- a/x16/x16s.cu
+++ b/x16/x16s.cu
@@ -584,7 +584,7 @@ extern "C" void free_x16s(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 

--- a/x17/hmq17.cu
+++ b/x17/hmq17.cu
@@ -523,7 +523,7 @@ extern "C" void free_hmq17(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 	cudaFree(d_hash_br2[thr_id]);

--- a/x17/x17.cu
+++ b/x17/x17.cu
@@ -299,7 +299,7 @@ extern "C" void free_x17(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 

--- a/zr5.cu
+++ b/zr5.cu
@@ -490,7 +490,7 @@ extern "C" void free_zr5(int thr_id)
 	if (!init[thr_id])
 		return;
 
-	cudaThreadSynchronize();
+	cudaDeviceSynchronize();
 
 	cudaFree(d_hash[thr_id]);
 


### PR DESCRIPTION
The cudaThreadSynchronize function is now deprecated and it might be
removed from the future versions of CUDA. This commit replaces it with
cudaDeviceSynchronize function.